### PR TITLE
feat: smooth 60 fps video — threaded encode, NVENC, client pacing

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -102,6 +102,8 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: recursive
 
       - name: Install build dependencies
         run: >
@@ -116,7 +118,7 @@ jobs:
           path: third_party/ffmpeg-min
           key: ffmpeg-min-${{ matrix.os }}-${{ hashFiles('scripts/build-ffmpeg.sh') }}
 
-      - name: Build minimal FFmpeg (static, h264 decode only)
+      - name: Build minimal FFmpeg (static, h264 decode + swscale)
         run: scripts/build-ffmpeg.sh
 
       - name: Cache quiche

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -12,7 +12,8 @@ redistribution of Deskhub under the MIT License.
 
 | Component | License | Linkage |
 | --- | --- | --- |
-| [FFmpeg](https://ffmpeg.org) 8.0 — `libavcodec`, `libavutil` | LGPL-2.1-or-later | **static** |
+| [FFmpeg](https://ffmpeg.org) 8.0 — `libavcodec`, `libswscale`, `libavutil` | LGPL-2.1-or-later | **static** |
+| [nv-codec-headers](https://github.com/FFmpeg/nv-codec-headers) (NVENC SDK 13.0 headers) | MIT | headers only |
 | [GTK](https://www.gtk.org) 3 | LGPL-2.1-or-later | dynamic |
 | [PipeWire](https://pipewire.org) 0.3 | MIT | dynamic |
 | [libva](https://github.com/intel/libva) / `libva-drm` | MIT | dynamic |
@@ -26,9 +27,10 @@ redistribution of Deskhub under the MIT License.
 The Linux app is the only target that bundles FFmpeg. It is built from unmodified
 upstream FFmpeg 8.0 sources by [`scripts/build-ffmpeg.sh`](scripts/build-ffmpeg.sh),
 configured **without** `--enable-gpl` and **without** `--enable-nonfree`, with only the
-native H.264 decoder and the VA-API hwaccel enabled. The resulting `libavcodec` and
-`libavutil` are therefore covered by the GNU Lesser General Public License, version 2.1
-or later — full text in [`licenses/LGPL-2.1.txt`](licenses/LGPL-2.1.txt).
+native H.264 decoder, the VA-API hwaccel and `libswscale` enabled. The resulting
+`libavcodec`, `libswscale` and `libavutil` are therefore covered by the GNU Lesser
+General Public License, version 2.1 or later — full text in
+[`licenses/LGPL-2.1.txt`](licenses/LGPL-2.1.txt).
 
 Because these libraries are linked statically, LGPL-2.1 §6 requires that recipients be
 able to relink the application against a modified version of FFmpeg. Deskhub satisfies
@@ -37,6 +39,11 @@ the MIT License, and `scripts/build-ffmpeg.sh` reproduces the exact FFmpeg build
 can substitute their own FFmpeg and rebuild with `make`.
 
 FFmpeg is not modified in any way. Upstream sources: <https://ffmpeg.org/download.html>.
+
+`third_party/nvenc-13.0` is a git submodule containing only the NVIDIA Video Codec SDK
+API headers as redistributed by the FFmpeg project under the MIT License. The NVENC
+implementation itself lives in the user's NVIDIA driver (`libnvidia-encode.so.1`,
+`libcuda.so.1`) and is resolved at runtime; it is not bundled.
 
 ### GTK 3 (LGPL-2.1-or-later, dynamically linked)
 

--- a/THIRD_PARTY_NOTICES.vi.md
+++ b/THIRD_PARTY_NOTICES.vi.md
@@ -15,7 +15,8 @@ chế việc phân phối lại Deskhub theo Giấy phép MIT.
 
 | Thành phần | Giấy phép | Cách liên kết |
 | --- | --- | --- |
-| [FFmpeg](https://ffmpeg.org) 8.0 — `libavcodec`, `libavutil` | LGPL-2.1-or-later | **tĩnh** |
+| [FFmpeg](https://ffmpeg.org) 8.0 — `libavcodec`, `libswscale`, `libavutil` | LGPL-2.1-or-later | **tĩnh** |
+| [nv-codec-headers](https://github.com/FFmpeg/nv-codec-headers) (header NVENC SDK 13.0) | MIT | chỉ header |
 | [GTK](https://www.gtk.org) 3 | LGPL-2.1-or-later | động |
 | [PipeWire](https://pipewire.org) 0.3 | MIT | động |
 | [libva](https://github.com/intel/libva) / `libva-drm` | MIT | động |
@@ -29,9 +30,9 @@ chế việc phân phối lại Deskhub theo Giấy phép MIT.
 App Linux là mục tiêu build duy nhất có đóng gói kèm FFmpeg. Nó được dựng từ mã nguồn
 FFmpeg 8.0 nguyên bản của thượng nguồn bằng
 [`scripts/build-ffmpeg.sh`](scripts/build-ffmpeg.sh), cấu hình **không** có
-`--enable-gpl` và **không** có `--enable-nonfree`, chỉ bật bộ giải mã H.264 nội tại và
-hwaccel VA-API. Do đó `libavcodec` và `libavutil` thu được nằm dưới GNU Lesser General
-Public License, phiên bản 2.1 hoặc mới hơn — toàn văn trong
+`--enable-gpl` và **không** có `--enable-nonfree`, chỉ bật bộ giải mã H.264 nội tại,
+hwaccel VA-API và `libswscale`. Do đó `libavcodec`, `libswscale` và `libavutil` thu được
+nằm dưới GNU Lesser General Public License, phiên bản 2.1 hoặc mới hơn — toàn văn trong
 [`licenses/LGPL-2.1.txt`](licenses/LGPL-2.1.txt).
 
 Vì các thư viện này được liên kết tĩnh, LGPL-2.1 §6 yêu cầu người nhận phải có khả năng
@@ -42,6 +43,11 @@ thay bằng FFmpeg của riêng mình và dựng lại bằng `make`.
 
 FFmpeg không bị chỉnh sửa dưới bất kỳ hình thức nào. Mã nguồn thượng nguồn:
 <https://ffmpeg.org/download.html>.
+
+`third_party/nvenc-13.0` là một git submodule chỉ chứa các header API của NVIDIA Video
+Codec SDK, do dự án FFmpeg phân phối lại dưới Giấy phép MIT. Bản thân phần hiện thực
+NVENC nằm trong driver NVIDIA của người dùng (`libnvidia-encode.so.1`, `libcuda.so.1`)
+và được nạp lúc chạy; nó không được đóng gói kèm.
 
 ### GTK 3 (LGPL-2.1-or-later, liên kết động)
 

--- a/client/linux/CMakeLists.txt
+++ b/client/linux/CMakeLists.txt
@@ -32,12 +32,30 @@ if(NOT EXISTS ${FFMPEG_MIN_DIR}/lib/libavcodec.a)
     return()
 endif()
 
+if(NOT EXISTS ${FFMPEG_MIN_DIR}/lib/libswscale.a)
+    message(${deskhub_skip_level}
+        "Deskhub: skipping the Ubuntu app — third_party/ffmpeg-min predates the "
+        "swscale-enabled build. Re-run 'scripts/build-ffmpeg.sh'.")
+    return()
+endif()
+
 add_library(ffmpeg_min INTERFACE)
 target_include_directories(ffmpeg_min SYSTEM INTERFACE ${FFMPEG_MIN_DIR}/include)
 target_link_libraries(ffmpeg_min INTERFACE
     ${FFMPEG_MIN_DIR}/lib/libavcodec.a
+    ${FFMPEG_MIN_DIR}/lib/libswscale.a
     ${FFMPEG_MIN_DIR}/lib/libavutil.a
 )
+
+option(DESKHUB_NVENC "Encode on NVIDIA GPUs through NVENC when one is present" ON)
+set(NVENC_HEADERS_DIR ${CMAKE_SOURCE_DIR}/third_party/nvenc-13.0/include)
+if(DESKHUB_NVENC AND NOT EXISTS ${NVENC_HEADERS_DIR}/ffnvcodec/nvEncodeAPI.h)
+    message(${deskhub_skip_level}
+        "Deskhub: skipping the Ubuntu app — the third_party/nvenc-13.0 submodule is "
+        "not checked out. Run 'git submodule update --init', or pass "
+        "-DDESKHUB_NVENC=OFF to build an app that can only encode through VA-API.")
+    return()
+endif()
 
 pkg_check_modules(DESKHUB_TRAY IMPORTED_TARGET ayatana-appindicator3-0.1)
 if(NOT DESKHUB_TRAY_FOUND)
@@ -61,6 +79,7 @@ add_executable(deskhub_app
 
     cpp/encode/VaDisplay.cpp
     cpp/encode/VaEncoder.cpp
+    $<$<BOOL:${DESKHUB_NVENC}>:cpp/encode/NvEncoder.cpp>
 
     cpp/decode/AvDecoder.cpp
     cpp/render/VideoRenderer.cpp
@@ -77,6 +96,11 @@ target_include_directories(deskhub_app PRIVATE
 )
 
 target_link_libraries(deskhub_app PRIVATE core platform PkgConfig::DESKHUB_DEPS ffmpeg_min)
+if(DESKHUB_NVENC)
+    target_compile_definitions(deskhub_app PRIVATE DESKHUB_HAVE_NVENC)
+    target_include_directories(deskhub_app SYSTEM PRIVATE ${NVENC_HEADERS_DIR})
+    target_link_libraries(deskhub_app PRIVATE ${CMAKE_DL_LIBS})
+endif()
 if(DESKHUB_TRAY_FOUND)
     target_compile_definitions(deskhub_app PRIVATE DESKHUB_HAVE_APPINDICATOR)
     target_link_libraries(deskhub_app PRIVATE PkgConfig::DESKHUB_TRAY)

--- a/client/linux/cpp/AgentLoop.cpp
+++ b/client/linux/cpp/AgentLoop.cpp
@@ -14,7 +14,7 @@
 #include "deskhubp/diag/Log.h"
 #include "deskhubp/input/LocalInput.h"
 #include "deskhubp/media/PortalScreenCast.h"
-#include "encode/VaEncoder.h"
+#include "encode/HwEncoder.h"
 #include "input/InputInjector.h"
 
 #include "deskhub/control/FrameGate.h"
@@ -25,7 +25,7 @@
 
 namespace {
 
-using LinuxSourceBase = deskhubp::HostSourceBase<ScreenCapture, InputInjector, VaEncoder>;
+using LinuxSourceBase = deskhubp::HostSourceBase<ScreenCapture, InputInjector, HwEncoder>;
 
 struct SourcePipeline : LinuxSourceBase {
     SourcePipeline(uint32_t startBps, uint32_t minBps)
@@ -116,16 +116,19 @@ bool AgentLoop::Start(const std::vector<AgentSource>& sources, const AgentOption
 
         auto onPacket = engine->MakePacketSink(*p);
 
-        auto ensureEncoder = [p, fps, onPacket](uint32_t w, uint32_t h) -> bool {
+        auto ensureEncoder = [p, fps, onPacket](uint32_t w, uint32_t h,
+                                 FrameMemory frameKind) -> bool {
             if (p->encoder && p->encoder->IsOpen()) return true;
             EncoderConfig cfg = deskhub::MakeEncoderConfig(*p, {w, h}, fps);
             cfg.onPacket = onPacket;
-            auto enc = std::make_unique<VaEncoder>();
-            if (!enc->Init(cfg)) {
-                LOGE("[Agent][%s] VA-API refused to start an encoder.", p->name.c_str());
+            auto enc = std::make_unique<HwEncoder>();
+            if (!enc->Init(cfg, frameKind)) {
+                LOGE("[Agent][%s] No hardware encoder would start (NVENC or VA-API).",
+                    p->name.c_str());
                 p->failed.store(true);
                 return false;
             }
+            LOGI("[Agent][%s] Encoding with %s.", p->name.c_str(), enc->BackendName());
             p->encoder = std::move(enc);
             return true;
         };
@@ -148,9 +151,9 @@ bool AgentLoop::Start(const std::vector<AgentSource>& sources, const AgentOption
             p->lastFrameUs.store(fi.meta.timestampUs, std::memory_order_relaxed);
 
             if (!p->netReady.load(std::memory_order_acquire)) return;
-            if (!ensureEncoder(adm.encode.width, adm.encode.height)) return;
+            if (!ensureEncoder(adm.encode.width, adm.encode.height, fi.memory)) return;
             const bool idr = p->forceIdr.exchange(false);
-            VaEncoder* enc = p->encoder.get();
+            HwEncoder* enc = p->encoder.get();
             const bool ok = deskhubp::DiagEncode(*p, idr,
                 [enc, &fi, idr] { return enc->Encode(fi, fi.meta.timestampUs, idr); });
             if (!ok) {
@@ -244,7 +247,7 @@ bool AgentLoop::Start(const std::vector<AgentSource>& sources, const AgentOption
         auto lk = deskhubp::TryHoldEncoder(p.encMutex);
         if (!lk.owns_lock() || !p.encoder || !p.hasCachedFrame()) return;
         const bool idr = p.forceIdr.exchange(false);
-        VaEncoder* enc = p.encoder.get();
+        HwEncoder* enc = p.encoder.get();
         const bool ok = deskhubp::DiagEncode(p, idr,
             [enc, nowUs, idr] { return enc->EncodeLast(nowUs, idr); });
         if (!ok) {

--- a/client/linux/cpp/AgentLoop.cpp
+++ b/client/linux/cpp/AgentLoop.cpp
@@ -1,10 +1,13 @@
 #include "deskhubp/session/AgentLoop.h"
 
+#include <cstring>
 #include <functional>
 #include <memory>
 #include <mutex>
 #include <span>
+#include <thread>
 #include <utility>
+#include <vector>
 
 #include "capture/AudioCapture.h"
 #include "capture/ScreenCapture.h"
@@ -17,6 +20,7 @@
 #include "deskhub/control/FrameGate.h"
 #include "deskhub/control/StreamSize.h"
 #include "deskhub/diag/AgentDiag.h"
+#include "deskhub/media/FrameMailbox.h"
 #include "deskhub/session/HostRouter.h"
 
 namespace {
@@ -31,6 +35,28 @@ struct SourcePipeline : LinuxSourceBase {
     int32_t srcX = 0, srcY = 0;
 
     deskhub::FrameGate frameGate;
+
+    deskhub::media::FrameMailbox<CopiedFrame> encodeBox;
+    std::thread encodeThread;
+
+    std::vector<uint8_t> TakePixelBuffer() {
+        std::lock_guard<std::mutex> lk(pixelPoolMutex_);
+        if (pixelPool_.empty()) return {};
+        std::vector<uint8_t> buffer = std::move(pixelPool_.back());
+        pixelPool_.pop_back();
+        return buffer;
+    }
+
+    void ReturnPixelBuffer(std::vector<uint8_t>&& buffer) {
+        std::lock_guard<std::mutex> lk(pixelPoolMutex_);
+        if (pixelPool_.size() < kPixelPoolDepth) pixelPool_.push_back(std::move(buffer));
+    }
+
+private:
+    static constexpr size_t kPixelPoolDepth = 2;
+
+    std::mutex pixelPoolMutex_;
+    std::vector<std::vector<uint8_t>> pixelPool_;
 };
 
 SourcePipeline& Pipeline(deskhubp::HostSource& st) {
@@ -104,10 +130,7 @@ bool AgentLoop::Start(const std::vector<AgentSource>& sources, const AgentOption
             return true;
         };
 
-        auto onFrame = [p, ensureEncoder, maxDim](const LinuxFrameInfo& fi) {
-            p->captured.fetch_add(1, std::memory_order_relaxed);
-            if (p->failed.load()) return;
-
+        auto encodeAdmitted = [p, ensureEncoder, maxDim](const LinuxFrameInfo& fi) {
             std::lock_guard<std::mutex> lk(p->encMutex);
 
             const deskhub::FrameAdmission adm = deskhub::AdmitCapturedFrame(*p, fi.meta.width,
@@ -121,10 +144,6 @@ bool AgentLoop::Start(const std::vector<AgentSource>& sources, const AgentOption
             if (!adm.pauseNote.empty())
                 LOGI("[Agent][%s] %s", p->name.c_str(), adm.pauseNote.c_str());
             if (adm.drop) return;
-
-            if (!p->frameGate.Admit(p->curFps.load(std::memory_order_relaxed),
-                    fi.meta.timestampUs))
-                return;
 
             p->lastFrameUs.store(fi.meta.timestampUs, std::memory_order_relaxed);
 
@@ -143,16 +162,53 @@ bool AgentLoop::Start(const std::vector<AgentSource>& sources, const AgentOption
             p->SetCachedFrame(enc->haveSourceFrame());
         };
 
+        auto onFrame = [p, encodeAdmitted](const LinuxFrameInfo& fi) {
+            p->captured.fetch_add(1, std::memory_order_relaxed);
+            if (p->failed.load()) return;
+
+            if (!p->frameGate.Admit(p->curFps.load(std::memory_order_relaxed),
+                    fi.meta.timestampUs))
+                return;
+
+            if (fi.memory == FrameMemory::DmaBuf) {
+                encodeAdmitted(fi);
+                return;
+            }
+
+            CopiedFrame copy;
+            copy.pixels = p->TakePixelBuffer();
+            const size_t bytes = size_t(fi.stride) * fi.meta.height;
+            copy.pixels.resize(bytes);
+            std::memcpy(copy.pixels.data(), fi.handle, bytes);
+            copy.stride = fi.stride;
+            copy.drmFormat = fi.drmFormat;
+            copy.meta = fi.meta;
+            if (auto displaced = p->encodeBox.Put(std::move(copy)))
+                p->ReturnPixelBuffer(std::move(displaced->pixels));
+        };
+
+        p->encodeThread = std::thread([p, encodeAdmitted] {
+            CopiedFrame copy;
+            while (p->encodeBox.TakeWait(copy)) {
+                encodeAdmitted(FrameFromCopy(copy));
+                p->ReturnPixelBuffer(std::move(copy.pixels));
+            }
+        });
+
         if (!p->capture.Start(p->nodeId, deskhub::media::CaptureOptions{fps, maxDim}, onFrame)) {
             LOGE("[Agent][%s] Failed to start capture \xE2\x80\x94 skipping this source.",
                 p->name.c_str());
             p->failed.store(true);
+            p->encodeBox.Close();
+            p->encodeThread.join();
         }
     };
 
     policy.source.stopCapture = [](deskhubp::HostSource& st) {
         SourcePipeline& p = Pipeline(st);
         p.capture.Stop();
+        p.encodeBox.Close();
+        if (p.encodeThread.joinable()) p.encodeThread.join();
         std::lock_guard<std::mutex> lk(p.encMutex);
         if (p.encoder) p.encoder->Finish();
         p.SetCachedFrame(false);

--- a/client/linux/cpp/capture/CaptureTypes.h
+++ b/client/linux/cpp/capture/CaptureTypes.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <cstdint>
+#include <vector>
 
 #include "deskhub/media/CaptureContract.h"
 
@@ -27,3 +28,20 @@ struct LinuxFrameInfo : deskhub::media::CapturedFrame<const uint8_t*> {
 
     uint32_t drmFormat = 0;
 };
+
+struct CopiedFrame {
+    std::vector<uint8_t> pixels;
+    uint32_t stride = 0;
+    uint32_t drmFormat = 0;
+    deskhub::media::FrameMeta meta;
+};
+
+inline LinuxFrameInfo FrameFromCopy(const CopiedFrame& copy) {
+    LinuxFrameInfo fi;
+    fi.memory = FrameMemory::Mapped;
+    fi.handle = copy.pixels.data();
+    fi.stride = copy.stride;
+    fi.drmFormat = copy.drmFormat;
+    fi.meta = copy.meta;
+    return fi;
+}

--- a/client/linux/cpp/encode/HwEncoder.h
+++ b/client/linux/cpp/encode/HwEncoder.h
@@ -1,0 +1,95 @@
+#pragma once
+#include <cstdint>
+#include <memory>
+
+#include "capture/CaptureTypes.h"
+#include "encode/VaEncoder.h"
+
+#include "deskhub/media/VideoContract.h"
+#include "deskhub/media/VideoTypes.h"
+
+#ifdef DESKHUB_HAVE_NVENC
+#include "encode/NvEncoder.h"
+#endif
+
+class HwEncoder {
+public:
+    bool Init(const deskhub::media::EncoderConfig& cfg, FrameMemory frameKind) {
+#ifdef DESKHUB_HAVE_NVENC
+        if (frameKind == FrameMemory::Mapped && NvEncoder::DriverPresent()) {
+            auto nv = std::make_unique<NvEncoder>();
+            if (nv->Init(cfg)) {
+                nv_ = std::move(nv);
+                return true;
+            }
+        }
+#else
+        (void)frameKind;
+#endif
+        auto va = std::make_unique<VaEncoder>();
+        if (!va->Init(cfg)) return false;
+        va_ = std::move(va);
+        return true;
+    }
+
+    bool Encode(const LinuxFrameInfo& fi, uint64_t timestampUs, bool forceKeyframe) {
+#ifdef DESKHUB_HAVE_NVENC
+        if (nv_) {
+            if (fi.memory != FrameMemory::Mapped) return false;
+            return nv_->Encode(fi, timestampUs, forceKeyframe);
+        }
+#endif
+        return va_ && va_->Encode(fi, timestampUs, forceKeyframe);
+    }
+
+    bool EncodeLast(uint64_t timestampUs, bool forceKeyframe) {
+#ifdef DESKHUB_HAVE_NVENC
+        if (nv_) return nv_->EncodeLast(timestampUs, forceKeyframe);
+#endif
+        return va_ && va_->EncodeLast(timestampUs, forceKeyframe);
+    }
+
+    bool haveSourceFrame() const {
+#ifdef DESKHUB_HAVE_NVENC
+        if (nv_) return nv_->haveSourceFrame();
+#endif
+        return va_ && va_->haveSourceFrame();
+    }
+
+    bool SetBitrate(uint32_t bitrateBps) {
+#ifdef DESKHUB_HAVE_NVENC
+        if (nv_) return nv_->SetBitrate(bitrateBps);
+#endif
+        return va_ && va_->SetBitrate(bitrateBps);
+    }
+
+    void Finish() {
+#ifdef DESKHUB_HAVE_NVENC
+        if (nv_) nv_->Finish();
+#endif
+        if (va_) va_->Finish();
+    }
+
+    bool IsOpen() const {
+#ifdef DESKHUB_HAVE_NVENC
+        if (nv_) return nv_->IsOpen();
+#endif
+        return va_ && va_->IsOpen();
+    }
+
+    const char* BackendName() const {
+#ifdef DESKHUB_HAVE_NVENC
+        if (nv_) return nv_->BackendName();
+#endif
+        return va_ ? va_->BackendName() : "none";
+    }
+
+private:
+#ifdef DESKHUB_HAVE_NVENC
+    std::unique_ptr<NvEncoder> nv_;
+#endif
+    std::unique_ptr<VaEncoder> va_;
+};
+
+static_assert(deskhub::media::VideoEncoderLike<HwEncoder, const LinuxFrameInfo&>,
+    "HwEncoder must match the shared encoder signature");

--- a/client/linux/cpp/encode/NvEncoder.cpp
+++ b/client/linux/cpp/encode/NvEncoder.cpp
@@ -25,11 +25,11 @@ namespace {
 
 AVPixelFormat PixelFormatFor(uint32_t drmFormat) {
     switch (drmFormat) {
-    case DRM_FORMAT_XRGB8888: return AV_PIX_FMT_BGR0;
-    case DRM_FORMAT_ARGB8888: return AV_PIX_FMT_BGRA;
-    case DRM_FORMAT_XBGR8888: return AV_PIX_FMT_RGB0;
-    case DRM_FORMAT_ABGR8888: return AV_PIX_FMT_RGBA;
-    default: return AV_PIX_FMT_NONE;
+        case DRM_FORMAT_XRGB8888: return AV_PIX_FMT_BGR0;
+        case DRM_FORMAT_ARGB8888: return AV_PIX_FMT_BGRA;
+        case DRM_FORMAT_XBGR8888: return AV_PIX_FMT_RGB0;
+        case DRM_FORMAT_ABGR8888: return AV_PIX_FMT_RGBA;
+        default: return AV_PIX_FMT_NONE;
     }
 }
 

--- a/client/linux/cpp/encode/NvEncoder.cpp
+++ b/client/linux/cpp/encode/NvEncoder.cpp
@@ -1,0 +1,371 @@
+#include "encode/NvEncoder.h"
+
+#include <drm_fourcc.h>
+
+extern "C" {
+#include <libswscale/swscale.h>
+}
+
+#include <ffnvcodec/dynlink_cuda.h>
+#include <ffnvcodec/nvEncodeAPI.h>
+
+#include <ffnvcodec/dynlink_loader.h>
+
+#include <cstring>
+#include <span>
+#include <vector>
+
+#include "deskhub/media/H264Sps.h"
+#include "deskhub/media/RatePlan.h"
+#include "deskhubp/diag/Log.h"
+
+using deskhub::media::EncoderConfig;
+
+namespace {
+
+AVPixelFormat PixelFormatFor(uint32_t drmFormat) {
+    switch (drmFormat) {
+    case DRM_FORMAT_XRGB8888: return AV_PIX_FMT_BGR0;
+    case DRM_FORMAT_ARGB8888: return AV_PIX_FMT_BGRA;
+    case DRM_FORMAT_XBGR8888: return AV_PIX_FMT_RGB0;
+    case DRM_FORMAT_ABGR8888: return AV_PIX_FMT_RGBA;
+    default: return AV_PIX_FMT_NONE;
+    }
+}
+
+uint32_t DriverNvencVersion(NvencFunctions* nv) {
+    uint32_t version = 0;
+    if (nv->NvEncodeAPIGetMaxSupportedVersion(&version) != NV_ENC_SUCCESS) return 0;
+    return version;
+}
+
+constexpr uint32_t kHeaderNvencVersion = (NVENCAPI_MAJOR_VERSION << 4) | NVENCAPI_MINOR_VERSION;
+
+}
+
+struct NvEncoder::Impl {
+    CudaFunctions* cu = nullptr;
+    NvencFunctions* nv = nullptr;
+    NV_ENCODE_API_FUNCTION_LIST fn{};
+    CUcontext cuCtx = nullptr;
+    void* session = nullptr;
+    NV_ENC_INPUT_PTR inputBuf = nullptr;
+    NV_ENC_OUTPUT_PTR bitstream = nullptr;
+
+    NV_ENC_INITIALIZE_PARAMS init{};
+    NV_ENC_CONFIG encCfg{};
+
+    SwsContext* sws = nullptr;
+    uint32_t swsSrcW = 0, swsSrcH = 0, swsSrcStride = 0;
+    AVPixelFormat swsSrcFmt = AV_PIX_FMT_NONE;
+
+    EncoderConfig cfg{};
+    std::vector<uint8_t> lastScaled;
+    bool haveSource = false;
+
+    const char* LastApiError() {
+        const char* msg =
+            session && fn.nvEncGetLastErrorString ? fn.nvEncGetLastErrorString(session) : nullptr;
+        return msg ? msg : "no detail";
+    }
+
+    bool PushCtx() {
+        return cu->cuCtxPushCurrent(cuCtx) == CUDA_SUCCESS;
+    }
+
+    void PopCtx() {
+        CUcontext dummy = nullptr;
+        cu->cuCtxPopCurrent(&dummy);
+    }
+
+    void ApplyRateControl(uint32_t bitrateBps) {
+        const deskhub::media::RatePlan plan =
+            deskhub::media::PlanRateControl(bitrateBps, cfg.fps, cfg.lowLatency);
+        encCfg.rcParams.rateControlMode = NV_ENC_PARAMS_RC_CBR;
+        encCfg.rcParams.averageBitRate = bitrateBps;
+        encCfg.rcParams.maxBitRate = bitrateBps;
+        encCfg.rcParams.vbvBufferSize = plan.vbvBits;
+        encCfg.rcParams.vbvInitialDelay = plan.vbvInitialBits;
+    }
+
+    bool EncodeScaled(uint64_t timestampUs, bool forceKeyframe) {
+        NV_ENC_LOCK_INPUT_BUFFER lock{};
+        lock.version = NV_ENC_LOCK_INPUT_BUFFER_VER;
+        lock.inputBuffer = inputBuf;
+        if (fn.nvEncLockInputBuffer(session, &lock) != NV_ENC_SUCCESS) {
+            LOGE("[NvEnc] input buffer lock failed: %s", LastApiError());
+            return false;
+        }
+        const uint32_t rowBytes = cfg.width * 4;
+        auto* dst = static_cast<uint8_t*>(lock.bufferDataPtr);
+        for (uint32_t y = 0; y < cfg.height; ++y)
+            std::memcpy(dst + size_t(y) * lock.pitch, lastScaled.data() + size_t(y) * rowBytes,
+                rowBytes);
+        const uint32_t pitch = lock.pitch;
+        fn.nvEncUnlockInputBuffer(session, inputBuf);
+
+        NV_ENC_PIC_PARAMS pic{};
+        pic.version = NV_ENC_PIC_PARAMS_VER;
+        pic.inputWidth = cfg.width;
+        pic.inputHeight = cfg.height;
+        pic.inputPitch = pitch;
+        pic.inputBuffer = inputBuf;
+        pic.outputBitstream = bitstream;
+        pic.bufferFmt = NV_ENC_BUFFER_FORMAT_ARGB;
+        pic.pictureStruct = NV_ENC_PIC_STRUCT_FRAME;
+        pic.inputTimeStamp = timestampUs;
+        if (forceKeyframe)
+            pic.encodePicFlags = NV_ENC_PIC_FLAG_FORCEIDR | NV_ENC_PIC_FLAG_OUTPUT_SPSPPS;
+        const NVENCSTATUS encoded = fn.nvEncEncodePicture(session, &pic);
+        if (encoded == NV_ENC_ERR_NEED_MORE_INPUT) return true;
+        if (encoded != NV_ENC_SUCCESS) {
+            LOGE("[NvEnc] encode failed: %s", LastApiError());
+            return false;
+        }
+
+        NV_ENC_LOCK_BITSTREAM out{};
+        out.version = NV_ENC_LOCK_BITSTREAM_VER;
+        out.outputBitstream = bitstream;
+        if (fn.nvEncLockBitstream(session, &out) != NV_ENC_SUCCESS) {
+            LOGE("[NvEnc] bitstream lock failed: %s", LastApiError());
+            return false;
+        }
+        const bool keyframe = out.pictureType == NV_ENC_PIC_TYPE_IDR;
+        const auto* data = static_cast<const uint8_t*>(out.bitstreamBufferPtr);
+        size_t size = out.bitstreamSizeInBytes;
+        std::vector<uint8_t> zeroReorder;
+        if (keyframe && size) {
+            zeroReorder = deskhub::media::AnnexBStreamWithZeroReorder(
+                std::span<const uint8_t>(data, size));
+            if (!zeroReorder.empty()) {
+                data = zeroReorder.data();
+                size = zeroReorder.size();
+            }
+        }
+        if (cfg.onPacket && size) cfg.onPacket(data, size, timestampUs, keyframe);
+        fn.nvEncUnlockBitstream(session, bitstream);
+        return true;
+    }
+
+    void Shutdown() {
+        if (session) {
+            NV_ENC_PIC_PARAMS eos{};
+            eos.version = NV_ENC_PIC_PARAMS_VER;
+            eos.encodePicFlags = NV_ENC_PIC_FLAG_EOS;
+            fn.nvEncEncodePicture(session, &eos);
+            if (inputBuf) fn.nvEncDestroyInputBuffer(session, inputBuf);
+            if (bitstream) fn.nvEncDestroyBitstreamBuffer(session, bitstream);
+            fn.nvEncDestroyEncoder(session);
+            session = nullptr;
+            inputBuf = nullptr;
+            bitstream = nullptr;
+        }
+        if (sws) {
+            sws_freeContext(sws);
+            sws = nullptr;
+        }
+        if (cuCtx) {
+            cu->cuCtxDestroy(cuCtx);
+            cuCtx = nullptr;
+        }
+        if (nv) nvenc_free_functions(&nv);
+        if (cu) cuda_free_functions(&cu);
+        haveSource = false;
+        lastScaled.clear();
+    }
+};
+
+NvEncoder::NvEncoder() : impl_(std::make_unique<Impl>()) {}
+
+NvEncoder::~NvEncoder() {
+    impl_->Shutdown();
+}
+
+bool NvEncoder::DriverPresent() {
+    static const bool present = [] {
+        CudaFunctions* cu = nullptr;
+        NvencFunctions* nv = nullptr;
+        if (cuda_load_functions(&cu, nullptr) < 0) return false;
+        if (nvenc_load_functions(&nv, nullptr) < 0) {
+            cuda_free_functions(&cu);
+            return false;
+        }
+        const uint32_t driver = DriverNvencVersion(nv);
+        nvenc_free_functions(&nv);
+        cuda_free_functions(&cu);
+        if (driver < kHeaderNvencVersion) {
+            LOGI("[NvEnc] driver speaks NVENC API %u.%u but %u.%u is needed — not using it.",
+                driver >> 4, driver & 0xF, NVENCAPI_MAJOR_VERSION, NVENCAPI_MINOR_VERSION);
+            return false;
+        }
+        return true;
+    }();
+    return present;
+}
+
+bool NvEncoder::Init(const EncoderConfig& cfg) {
+    Impl* im = impl_.get();
+    im->cfg = cfg;
+
+    if (cuda_load_functions(&im->cu, nullptr) < 0) return false;
+    if (nvenc_load_functions(&im->nv, nullptr) < 0) return false;
+    if (DriverNvencVersion(im->nv) < kHeaderNvencVersion) return false;
+
+    if (im->cu->cuInit(0) != CUDA_SUCCESS) return false;
+    int deviceCount = 0;
+    if (im->cu->cuDeviceGetCount(&deviceCount) != CUDA_SUCCESS || deviceCount < 1) return false;
+    CUdevice device = 0;
+    if (im->cu->cuDeviceGet(&device, 0) != CUDA_SUCCESS) return false;
+    if (im->cu->cuCtxCreate(&im->cuCtx, 0, device) != CUDA_SUCCESS) return false;
+
+    im->fn.version = NV_ENCODE_API_FUNCTION_LIST_VER;
+    if (im->nv->NvEncodeAPICreateInstance(&im->fn) != NV_ENC_SUCCESS) return false;
+
+    NV_ENC_OPEN_ENCODE_SESSION_EX_PARAMS open{};
+    open.version = NV_ENC_OPEN_ENCODE_SESSION_EX_PARAMS_VER;
+    open.deviceType = NV_ENC_DEVICE_TYPE_CUDA;
+    open.device = im->cuCtx;
+    open.apiVersion = NVENCAPI_VERSION;
+    if (im->fn.nvEncOpenEncodeSessionEx(&open, &im->session) != NV_ENC_SUCCESS) {
+        im->session = nullptr;
+        return false;
+    }
+
+    NV_ENC_PRESET_CONFIG preset{};
+    preset.version = NV_ENC_PRESET_CONFIG_VER;
+    preset.presetCfg.version = NV_ENC_CONFIG_VER;
+    if (im->fn.nvEncGetEncodePresetConfigEx(im->session, NV_ENC_CODEC_H264_GUID,
+            NV_ENC_PRESET_P4_GUID, NV_ENC_TUNING_INFO_ULTRA_LOW_LATENCY,
+            &preset) != NV_ENC_SUCCESS) {
+        LOGE("[NvEnc] preset config query failed: %s", im->LastApiError());
+        return false;
+    }
+    im->encCfg = preset.presetCfg;
+    im->encCfg.profileGUID = NV_ENC_H264_PROFILE_HIGH_GUID;
+    im->encCfg.gopLength = NVENC_INFINITE_GOPLENGTH;
+    im->encCfg.frameIntervalP = 1;
+    im->encCfg.encodeCodecConfig.h264Config.idrPeriod = NVENC_INFINITE_GOPLENGTH;
+    im->encCfg.encodeCodecConfig.h264Config.repeatSPSPPS = 1;
+    im->ApplyRateControl(cfg.bitrateBps);
+
+    im->init.version = NV_ENC_INITIALIZE_PARAMS_VER;
+    im->init.encodeGUID = NV_ENC_CODEC_H264_GUID;
+    im->init.presetGUID = NV_ENC_PRESET_P4_GUID;
+    im->init.tuningInfo = NV_ENC_TUNING_INFO_ULTRA_LOW_LATENCY;
+    im->init.encodeWidth = cfg.width;
+    im->init.encodeHeight = cfg.height;
+    im->init.darWidth = cfg.width;
+    im->init.darHeight = cfg.height;
+    im->init.maxEncodeWidth = cfg.width;
+    im->init.maxEncodeHeight = cfg.height;
+    im->init.frameRateNum = cfg.fps ? cfg.fps : 60;
+    im->init.frameRateDen = 1;
+    im->init.enablePTD = 1;
+    im->init.encodeConfig = &im->encCfg;
+
+    if (!im->PushCtx()) return false;
+    const NVENCSTATUS st = im->fn.nvEncInitializeEncoder(im->session, &im->init);
+    im->PopCtx();
+    if (st != NV_ENC_SUCCESS) {
+        LOGE("[NvEnc] encoder init %ux%u @%u fps refused: %s", cfg.width, cfg.height, cfg.fps,
+            im->LastApiError());
+        return false;
+    }
+
+    NV_ENC_CREATE_INPUT_BUFFER in{};
+    in.version = NV_ENC_CREATE_INPUT_BUFFER_VER;
+    in.width = cfg.width;
+    in.height = cfg.height;
+    in.bufferFmt = NV_ENC_BUFFER_FORMAT_ARGB;
+    if (im->fn.nvEncCreateInputBuffer(im->session, &in) != NV_ENC_SUCCESS) {
+        LOGE("[NvEnc] input buffer creation failed: %s", im->LastApiError());
+        return false;
+    }
+    im->inputBuf = in.inputBuffer;
+
+    NV_ENC_CREATE_BITSTREAM_BUFFER out{};
+    out.version = NV_ENC_CREATE_BITSTREAM_BUFFER_VER;
+    if (im->fn.nvEncCreateBitstreamBuffer(im->session, &out) != NV_ENC_SUCCESS) {
+        LOGE("[NvEnc] bitstream buffer creation failed: %s", im->LastApiError());
+        return false;
+    }
+    im->bitstream = out.bitstreamBuffer;
+
+    im->lastScaled.assign(size_t(cfg.width) * cfg.height * 4, 0);
+    im->haveSource = false;
+    LOGI("[NvEnc] %ux%u @%u fps, %.1f Mbps CBR, ultra-low-latency — NVIDIA hardware encoder.",
+        cfg.width, cfg.height, cfg.fps, cfg.bitrateBps / 1e6);
+    return true;
+}
+
+bool NvEncoder::Encode(const LinuxFrameInfo& fi, uint64_t timestampUs, bool forceKeyframe) {
+    Impl* im = impl_.get();
+    if (!IsOpen()) return false;
+    if (fi.memory != FrameMemory::Mapped) return false;
+
+    const AVPixelFormat srcFmt = PixelFormatFor(fi.drmFormat);
+    if (srcFmt == AV_PIX_FMT_NONE) {
+        LOGE("[NvEnc] unsupported capture pixel format 0x%08x.", fi.drmFormat);
+        return false;
+    }
+
+    if (!im->sws || im->swsSrcW != fi.meta.width || im->swsSrcH != fi.meta.height ||
+        im->swsSrcStride != fi.stride || im->swsSrcFmt != srcFmt) {
+        if (im->sws) sws_freeContext(im->sws);
+        im->sws = sws_getContext(int(fi.meta.width), int(fi.meta.height), srcFmt,
+            int(im->cfg.width), int(im->cfg.height), AV_PIX_FMT_BGRA, SWS_FAST_BILINEAR, nullptr,
+            nullptr, nullptr);
+        if (!im->sws) {
+            LOGE("[NvEnc] swscale refused %ux%u -> %ux%u.", fi.meta.width, fi.meta.height,
+                im->cfg.width, im->cfg.height);
+            return false;
+        }
+        im->swsSrcW = fi.meta.width;
+        im->swsSrcH = fi.meta.height;
+        im->swsSrcStride = fi.stride;
+        im->swsSrcFmt = srcFmt;
+    }
+
+    const uint8_t* srcPlanes[1] = {fi.handle};
+    const int srcStrides[1] = {int(fi.stride)};
+    uint8_t* dstPlanes[1] = {im->lastScaled.data()};
+    const int dstStrides[1] = {int(im->cfg.width * 4)};
+    sws_scale(im->sws, srcPlanes, srcStrides, 0, int(fi.meta.height), dstPlanes, dstStrides);
+    im->haveSource = true;
+
+    return im->EncodeScaled(timestampUs, forceKeyframe);
+}
+
+bool NvEncoder::EncodeLast(uint64_t timestampUs, bool forceKeyframe) {
+    Impl* im = impl_.get();
+    if (!IsOpen() || !im->haveSource) return false;
+    return im->EncodeScaled(timestampUs, forceKeyframe);
+}
+
+bool NvEncoder::haveSourceFrame() const {
+    return impl_->haveSource;
+}
+
+bool NvEncoder::SetBitrate(uint32_t bitrateBps) {
+    Impl* im = impl_.get();
+    if (!IsOpen() || !bitrateBps || bitrateBps == im->cfg.bitrateBps) return IsOpen();
+    im->cfg.bitrateBps = bitrateBps;
+    im->ApplyRateControl(bitrateBps);
+
+    NV_ENC_RECONFIGURE_PARAMS re{};
+    re.version = NV_ENC_RECONFIGURE_PARAMS_VER;
+    re.reInitEncodeParams = im->init;
+    if (im->fn.nvEncReconfigureEncoder(im->session, &re) != NV_ENC_SUCCESS) {
+        LOGW("[NvEnc] bitrate reconfigure to %u bps failed: %s", bitrateBps, im->LastApiError());
+        return false;
+    }
+    return true;
+}
+
+void NvEncoder::Finish() {
+    impl_->Shutdown();
+}
+
+bool NvEncoder::IsOpen() const {
+    return impl_->session != nullptr;
+}

--- a/client/linux/cpp/encode/NvEncoder.h
+++ b/client/linux/cpp/encode/NvEncoder.h
@@ -1,0 +1,43 @@
+#pragma once
+#include <cstdint>
+#include <memory>
+
+#include "capture/CaptureTypes.h"
+
+#include "deskhub/media/VideoContract.h"
+#include "deskhub/media/VideoTypes.h"
+
+class NvEncoder {
+public:
+    NvEncoder();
+    ~NvEncoder();
+    NvEncoder(const NvEncoder&) = delete;
+    NvEncoder& operator=(const NvEncoder&) = delete;
+
+    static bool DriverPresent();
+
+    bool Init(const deskhub::media::EncoderConfig& cfg);
+
+    bool Encode(const LinuxFrameInfo& fi, uint64_t timestampUs, bool forceKeyframe);
+
+    bool EncodeLast(uint64_t timestampUs, bool forceKeyframe);
+
+    bool haveSourceFrame() const;
+
+    bool SetBitrate(uint32_t bitrateBps);
+
+    void Finish();
+
+    bool IsOpen() const;
+
+    const char* BackendName() const {
+        return "NVENC (hardware)";
+    }
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+static_assert(deskhub::media::VideoEncoderLike<NvEncoder, const LinuxFrameInfo&>,
+    "NvEncoder must match the shared encoder signature");

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -147,6 +147,7 @@ if(DESKHUB_CORE_TESTS)
         tests/media/ViewFitTests.cpp
         tests/media/SourceLabelTests.cpp
         tests/media/ViewerTitleTests.cpp
+        tests/media/FrameMailboxTests.cpp
 
         tests/session/BeaconTests.cpp
 

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -41,6 +41,7 @@ add_library(core STATIC
     src/control/StreamSize.cpp
     src/control/FrameGate.cpp
     src/control/ClockOffset.cpp
+    src/control/VideoPacer.cpp
     src/control/QualityLadder.cpp
 
     src/media/ViewFit.cpp
@@ -133,6 +134,7 @@ if(DESKHUB_CORE_TESTS)
         tests/control/StreamSizeTests.cpp
         tests/control/FrameGateTests.cpp
         tests/control/ClockOffsetTests.cpp
+        tests/control/VideoPacerTests.cpp
         tests/control/QualityLadderTests.cpp
 
         tests/diag/DiagTests.cpp

--- a/core/include/deskhub/control/VideoPacer.h
+++ b/core/include/deskhub/control/VideoPacer.h
@@ -1,0 +1,37 @@
+#pragma once
+#include <cstdint>
+
+#include "deskhub/control/ClockOffset.h"
+
+namespace deskhub {
+
+class VideoPacer {
+public:
+    static constexpr uint64_t kDefaultLeadUs = 33'000;
+    static constexpr uint64_t kResyncThresholdUs = 250'000;
+    static constexpr uint64_t kStreamJumpUs = 2'000'000;
+
+    explicit VideoPacer(uint64_t leadUs = kDefaultLeadUs) : leadUs_(leadUs) {}
+
+    void ObserveArrival(uint64_t ptsUs, uint64_t nowUs);
+
+    bool ready() const {
+        return offset_.ready();
+    }
+
+    int64_t DesiredTimebaseUs(uint64_t nowUs) const;
+
+    uint64_t DisplayTimeUs(uint64_t ptsUs, uint64_t nowUs) const;
+
+    bool NeedsResync(int64_t currentTimebaseUs, uint64_t nowUs) const;
+
+    void Reset() {
+        offset_.Reset();
+    }
+
+private:
+    ClockOffset offset_;
+    uint64_t leadUs_;
+};
+
+}

--- a/core/include/deskhub/media/FrameMailbox.h
+++ b/core/include/deskhub/media/FrameMailbox.h
@@ -1,0 +1,59 @@
+#pragma once
+#include <condition_variable>
+#include <cstdint>
+#include <mutex>
+#include <optional>
+#include <utility>
+
+namespace deskhub::media {
+
+template <class Frame>
+class FrameMailbox {
+public:
+    std::optional<Frame> Put(Frame&& frame) {
+        std::optional<Frame> displaced;
+        {
+            std::lock_guard<std::mutex> lk(mutex_);
+            if (closed_) return std::optional<Frame>(std::move(frame));
+            if (pending_) {
+                ++superseded_;
+                displaced = std::move(pending_);
+            }
+            pending_ = std::move(frame);
+        }
+        cv_.notify_one();
+        return displaced;
+    }
+
+    bool TakeWait(Frame& out) {
+        std::unique_lock<std::mutex> lk(mutex_);
+        cv_.wait(lk, [this] { return pending_.has_value() || closed_; });
+        if (!pending_) return false;
+        out = std::move(*pending_);
+        pending_.reset();
+        return true;
+    }
+
+    void Close() {
+        {
+            std::lock_guard<std::mutex> lk(mutex_);
+            closed_ = true;
+            pending_.reset();
+        }
+        cv_.notify_all();
+    }
+
+    uint64_t TakeSuperseded() {
+        std::lock_guard<std::mutex> lk(mutex_);
+        return std::exchange(superseded_, 0);
+    }
+
+private:
+    std::mutex mutex_;
+    std::condition_variable cv_;
+    std::optional<Frame> pending_;
+    bool closed_ = false;
+    uint64_t superseded_ = 0;
+};
+
+}

--- a/core/src/control/VideoPacer.cpp
+++ b/core/src/control/VideoPacer.cpp
@@ -1,0 +1,28 @@
+#include "deskhub/control/VideoPacer.h"
+
+namespace deskhub {
+
+void VideoPacer::ObserveArrival(uint64_t ptsUs, uint64_t nowUs) {
+    if (offset_.ready()) {
+        const int64_t raw = int64_t(nowUs) - int64_t(ptsUs);
+        const int64_t drift = raw - offset_.floorUs();
+        if (drift > int64_t(kStreamJumpUs) || drift < -int64_t(kStreamJumpUs)) offset_.Reset();
+    }
+    offset_.AddSample(ptsUs, nowUs);
+}
+
+int64_t VideoPacer::DesiredTimebaseUs(uint64_t nowUs) const {
+    return int64_t(nowUs) - offset_.floorUs() - int64_t(leadUs_);
+}
+
+uint64_t VideoPacer::DisplayTimeUs(uint64_t ptsUs, uint64_t nowUs) const {
+    const int64_t at = int64_t(ptsUs) + offset_.floorUs() + int64_t(leadUs_);
+    return at > int64_t(nowUs) ? uint64_t(at) : nowUs;
+}
+
+bool VideoPacer::NeedsResync(int64_t currentTimebaseUs, uint64_t nowUs) const {
+    const int64_t diff = currentTimebaseUs - DesiredTimebaseUs(nowUs);
+    return diff > int64_t(kResyncThresholdUs) || diff < -int64_t(kResyncThresholdUs);
+}
+
+}

--- a/core/tests/TestMain.cpp
+++ b/core/tests/TestMain.cpp
@@ -103,6 +103,9 @@ int main() {
     std::printf("--- control: clock offset / one-way latency ---\n");
     RunClockOffsetTests();
 
+    std::printf("--- control: video pacer (arrival jitter -> display cadence) ---\n");
+    RunVideoPacerTests();
+
     std::printf("--- control: quality ladder (fps + resolution vs bandwidth) ---\n");
     RunQualityLadderTests();
 

--- a/core/tests/TestMain.cpp
+++ b/core/tests/TestMain.cpp
@@ -139,6 +139,9 @@ int main() {
     std::printf("--- media: viewer window title (status + lock hint) ---\n");
     RunViewerTitleTests();
 
+    std::printf("--- media: latest-wins frame mailbox ---\n");
+    RunFrameMailboxTests();
+
     std::printf("--- beacon (pre-session LIST_SOURCES + PING) ---\n");
     RunBeaconTests();
 

--- a/core/tests/Tests.h
+++ b/core/tests/Tests.h
@@ -44,6 +44,7 @@ void RunQualityPresetTests();
 void RunViewFitTests();
 void RunSourceLabelTests();
 void RunViewerTitleTests();
+void RunFrameMailboxTests();
 void RunBeaconTests();
 void RunLanScanTests();
 void RunIpv4Tests();

--- a/core/tests/Tests.h
+++ b/core/tests/Tests.h
@@ -32,6 +32,7 @@ void RunControlTests();
 void RunStreamSizeTests();
 void RunFrameGateTests();
 void RunClockOffsetTests();
+void RunVideoPacerTests();
 void RunQualityLadderTests();
 void RunDiagTests();
 void RunMediaContractTests();

--- a/core/tests/control/VideoPacerTests.cpp
+++ b/core/tests/control/VideoPacerTests.cpp
@@ -1,0 +1,120 @@
+#include "Tests.h"
+#include "support/TestSupport.h"
+
+#include "deskhub/control/VideoPacer.h"
+
+#include <cstdint>
+#include <cstdio>
+
+using deskhub::VideoPacer;
+
+namespace {
+
+constexpr uint64_t kLeadUs = VideoPacer::kDefaultLeadUs;
+constexpr uint64_t kFrameUs = 16'667;
+constexpr uint64_t kTransitUs = 100'000;
+
+VideoPacer SteadyPacer(uint64_t frames, uint64_t& lastPts, uint64_t& lastNow) {
+    VideoPacer pacer;
+    for (uint64_t i = 0; i < frames; ++i) {
+        const uint64_t pts = 1'000'000 + i * kFrameUs;
+        const uint64_t jitterUs = (i % 4) * 3'000;
+        lastPts = pts;
+        lastNow = pts + kTransitUs + jitterUs;
+        pacer.ObserveArrival(lastPts, lastNow);
+    }
+    return pacer;
+}
+
+void TestSteadyStreamGetsTheLead() {
+    std::printf("[pacer] the fastest frame is scheduled one lead ahead of arrival...\n");
+    uint64_t pts = 0, now = 0;
+    VideoPacer pacer = SteadyPacer(64, pts, now);
+    Check(pacer.ready(), "the pacer is primed after a steady run");
+
+    const uint64_t fastestPts = pts + kFrameUs;
+    const uint64_t fastestNow = fastestPts + kTransitUs;
+    pacer.ObserveArrival(fastestPts, fastestNow);
+    Check(pacer.DisplayTimeUs(fastestPts, fastestNow) == fastestNow + kLeadUs,
+        "a zero-jitter frame displays exactly one lead after it arrives");
+
+    const uint64_t jitteredPts = fastestPts + kFrameUs;
+    const uint64_t jitteredNow = jitteredPts + kTransitUs + 10'000;
+    pacer.ObserveArrival(jitteredPts, jitteredNow);
+    Check(pacer.DisplayTimeUs(jitteredPts, jitteredNow) == jitteredNow + kLeadUs - 10'000,
+        "a jittered frame spends its slack and keeps the same display cadence");
+}
+
+void TestJitterRemovedFromCadence() {
+    std::printf("[pacer] display times follow the pts grid, not the arrival wobble...\n");
+    uint64_t pts = 0, now = 0;
+    VideoPacer pacer = SteadyPacer(64, pts, now);
+
+    uint64_t prevDisplay = 0;
+    for (uint64_t i = 1; i <= 4; ++i) {
+        const uint64_t p = pts + i * kFrameUs;
+        const uint64_t n = p + kTransitUs + (i % 2) * 9'000;
+        pacer.ObserveArrival(p, n);
+        const uint64_t display = pacer.DisplayTimeUs(p, n);
+        if (prevDisplay)
+            Check(display - prevDisplay == kFrameUs,
+                "consecutive display times are one frame interval apart");
+        prevDisplay = display;
+    }
+}
+
+void TestLateFrameDisplaysImmediately() {
+    std::printf("[pacer] a frame later than the lead is shown at once, not queued...\n");
+    uint64_t pts = 0, now = 0;
+    VideoPacer pacer = SteadyPacer(64, pts, now);
+
+    const uint64_t latePts = pts + kFrameUs;
+    const uint64_t lateNow = latePts + kTransitUs + kLeadUs + 20'000;
+    pacer.ObserveArrival(latePts, lateNow);
+    Check(pacer.DisplayTimeUs(latePts, lateNow) == lateNow,
+        "the display time clamps to now instead of the past");
+}
+
+void TestResyncThreshold() {
+    std::printf("[pacer] the timebase is nudged only past the resync threshold...\n");
+    uint64_t pts = 0, now = 0;
+    VideoPacer pacer = SteadyPacer(64, pts, now);
+
+    const int64_t desired = pacer.DesiredTimebaseUs(now);
+    Check(!pacer.NeedsResync(desired, now), "an exact timebase needs no resync");
+    Check(!pacer.NeedsResync(desired + 100'000, now), "a small drift is left to glide");
+    Check(pacer.NeedsResync(desired + 300'000, now), "a large forward drift forces a jump");
+    Check(pacer.NeedsResync(desired - 300'000, now), "a large backward drift forces a jump");
+}
+
+void TestStreamRestartResets() {
+    std::printf("[pacer] a pts jump is read as a new stream, not as huge jitter...\n");
+    uint64_t pts = 0, now = 0;
+    VideoPacer pacer = SteadyPacer(64, pts, now);
+
+    const uint64_t restartPts = 1'000;
+    const uint64_t restartNow = now + kFrameUs;
+    pacer.ObserveArrival(restartPts, restartNow);
+    Check(pacer.ready(), "the pacer reprimes on the first frame of the new stream");
+    Check(pacer.DisplayTimeUs(restartPts, restartNow) == restartNow + kLeadUs,
+        "the new stream starts on a fresh mapping instead of freezing");
+}
+
+void TestResetClears() {
+    std::printf("[pacer] reset forgets the mapping...\n");
+    uint64_t pts = 0, now = 0;
+    VideoPacer pacer = SteadyPacer(8, pts, now);
+    pacer.Reset();
+    Check(!pacer.ready(), "a reset pacer is unprimed");
+}
+
+}
+
+void RunVideoPacerTests() {
+    TestSteadyStreamGetsTheLead();
+    TestJitterRemovedFromCadence();
+    TestLateFrameDisplaysImmediately();
+    TestResyncThreshold();
+    TestStreamRestartResets();
+    TestResetClears();
+}

--- a/core/tests/media/FrameMailboxTests.cpp
+++ b/core/tests/media/FrameMailboxTests.cpp
@@ -1,0 +1,79 @@
+#include "Tests.h"
+#include "support/TestSupport.h"
+
+#include "deskhub/media/FrameMailbox.h"
+
+#include <cstdio>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+using deskhub::media::FrameMailbox;
+
+namespace {
+
+void TestLatestWins() {
+    std::printf("[mailbox] a newer frame replaces the one still waiting...\n");
+    FrameMailbox<int> box;
+    Check(!box.Put(1).has_value(), "the first frame displaces nothing");
+    Check(box.Put(2).value_or(0) == 1, "the second hands back the first");
+    Check(box.Put(3).value_or(0) == 2, "the third hands back the second");
+    int got = 0;
+    Check(box.TakeWait(got), "a frame is available");
+    Check(got == 3, "and it is the newest one");
+    Check(box.TakeSuperseded() == 2, "the two older frames count as superseded");
+    Check(box.TakeSuperseded() == 0, "the counter resets on read");
+}
+
+void TestTakeBlocksUntilPut() {
+    std::printf("[mailbox] take blocks until a frame arrives...\n");
+    FrameMailbox<std::string> box;
+    std::string got;
+    std::thread taker([&] { Check(box.TakeWait(got), "the blocked take returns a frame"); });
+    box.Put("frame");
+    taker.join();
+    Check(got == "frame", "and it is the frame that was put");
+}
+
+void TestCloseUnblocksAndRefuses() {
+    std::printf("[mailbox] close unblocks waiters and refuses later frames...\n");
+    FrameMailbox<int> box;
+    int got = 0;
+    std::thread taker([&] { Check(!box.TakeWait(got), "a waiter wakes empty-handed on close"); });
+    box.Close();
+    taker.join();
+
+    Check(box.Put(7).value_or(0) == 7, "a frame put after close bounces straight back");
+    Check(box.TakeSuperseded() == 0, "and is not counted as superseded");
+    std::thread after([&] { Check(!box.TakeWait(got), "take after close returns nothing"); });
+    after.join();
+}
+
+void TestCloseDropsPendingFrame() {
+    std::printf("[mailbox] close drops a frame that was never taken...\n");
+    FrameMailbox<std::vector<int>> box;
+    box.Put({1, 2, 3});
+    box.Close();
+    std::vector<int> got;
+    Check(!box.TakeWait(got), "the pending frame is gone after close");
+}
+
+void TestMoveOnlyFrames() {
+    std::printf("[mailbox] move-only payloads pass through without copies...\n");
+    FrameMailbox<std::unique_ptr<int>> box;
+    box.Put(std::make_unique<int>(42));
+    std::unique_ptr<int> got;
+    Check(box.TakeWait(got), "the frame arrives");
+    Check(got && *got == 42, "with its payload intact");
+}
+
+}
+
+void RunFrameMailboxTests() {
+    TestLatestWins();
+    TestTakeBlocksUntilPut();
+    TestCloseUnblocksAndRefuses();
+    TestCloseDropsPendingFrame();
+    TestMoveOnlyFrames();
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -202,6 +202,23 @@ on arm64 Linux, an Android emulator and the iOS Simulator.
 
 ## 9. Decisions worth remembering
 
+- **The Linux host encodes on its own thread, never in the capture callback**: encoding
+  inside PipeWire's `process` callback throttled capture to `1000 / enc_ms` fps and
+  turned every encode-time wobble into frame-cadence jitter on the client. Mapped
+  frames are copied once (buffers recycled through a small pool) and handed to a
+  dedicated encode thread through `FrameMailbox`, a latest-wins single-slot queue —
+  when the encoder falls behind, the freshest frame wins and the stale one is counted,
+  not queued. Dma-buf frames still encode inline: the compositor reuses their backing
+  memory the moment the callback returns, so they cannot outlive it.
+- **The Linux host picks its encoder by where the frame lives, not by what is
+  installed**: a dma-buf frame goes to VA-API, which can import it zero-copy on the
+  GPU that produced it; a mapped (CPU) frame goes to NVENC when an NVIDIA driver is
+  present, because once the pixels are in system memory the fastest encoder wins —
+  on a desktop rendered by the NVIDIA GPU the compositor renegotiates screencast to
+  shared memory anyway, and VA-API on the idle iGPU was measured at 23 ms a frame
+  against NVENC's 3. `HwEncoder` makes that call per encoder rebuild, and a frame of
+  the other kind arriving later returns `false`, which is the signal to rebuild.
+
 - **Audio is one frame per datagram, and a lost one is never chased**: a 20 ms Opus
   frame at 64 kbps measures about 160 bytes, 209 at its widest, against the 1180 bytes
   a datagram has room for — so the audio path has no packetizer, no FEC, no

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -219,6 +219,19 @@ on arm64 Linux, an Android emulator and the iOS Simulator.
   against NVENC's 3. `HwEncoder` makes that call per encoder rebuild, and a frame of
   the other kind arriving later returns `false`, which is the signal to rebuild.
 
+- **Apple viewers pace video by PTS on a control timebase, and the pacer never trusts
+  itself**: displaying every frame the moment it arrived made Wi-Fi arrival jitter
+  visible as judder while every latency number stayed excellent — cadence is not
+  latency. `VideoPacer` (core, tested offline) maps host PTS to local display time the
+  same way the e2e metric does — a windowed minimum of `arrival − pts` — plus one
+  ~33 ms lead that arrival jitter is paid from, and `VtDecoder` drives an
+  `AVSampleBufferDisplayLayer` control timebase from it, resyncing only past a 250 ms
+  divergence. A pts jump over 2 s reads as a new stream, not as jitter, so the mapping
+  reprimes instead of freezing for a window. Because the renderer honoring an external
+  timebase cannot be proven on every OS version from here, the decoder watches its own
+  back: a run of paced frames swallowed by a full renderer queue flips it back to
+  display-immediately and flushes, trading the smoothing away rather than the picture.
+
 - **Audio is one frame per datagram, and a lost one is never chased**: a 20 ms Opus
   frame at 64 kbps measures about 160 bytes, 209 at its widest, against the 1180 bytes
   a datagram has room for — so the audio path has no packetizer, no FEC, no

--- a/docs/ARCHITECTURE.vi.md
+++ b/docs/ARCHITECTURE.vi.md
@@ -200,6 +200,23 @@ iOS Simulator.
 
 ## 9. Các quyết định đáng nhớ
 
+- **Host Linux encode trên thread riêng, không bao giờ trong callback capture**: encode
+  ngay trong callback `process` của PipeWire từng ghìm capture xuống `1000 / enc_ms`
+  fps và biến mọi dao động thời gian encode thành rung nhịp khung hình phía client.
+  Frame dạng mapped được copy một lần (buffer tái dùng qua một pool nhỏ) rồi chuyển cho
+  thread encode riêng qua `FrameMailbox`, một hàng đợi một-chỗ kiểu mới-nhất-thắng —
+  khi encoder chậm chân, frame mới nhất thắng và frame cũ được đếm chứ không xếp hàng.
+  Frame dma-buf vẫn encode tại chỗ: compositor tái dùng bộ nhớ của chúng ngay khi
+  callback trả về, nên chúng không thể sống lâu hơn callback.
+- **Host Linux chọn encoder theo nơi frame nằm, không phải theo thứ được cài**: frame
+  dma-buf đi vào VA-API, nơi import được zero-copy trên đúng GPU đã tạo ra nó; frame
+  mapped (CPU) đi vào NVENC khi có driver NVIDIA, vì một khi pixel đã nằm trong bộ nhớ
+  hệ thống thì encoder nhanh nhất thắng — trên desktop do GPU NVIDIA render, compositor
+  đằng nào cũng thương lượng lại screencast về shared memory, và VA-API trên iGPU nhàn
+  rỗi đo được 23 ms một frame so với 3 ms của NVENC. `HwEncoder` đưa ra lựa chọn đó mỗi
+  lần dựng lại encoder, và một frame khác loại đến sau sẽ trả về `false` — đó là tín
+  hiệu để dựng lại.
+
 - **Audio là một khung một datagram, và mất thì không đuổi theo**: một khung Opus 20 ms
   ở 64 kbps đo được khoảng 160 byte, rộng nhất 209 byte, so với 1180 byte một datagram
   chứa được — nên đường audio không có packetizer, không FEC, không reassembler, không

--- a/docs/ARCHITECTURE.vi.md
+++ b/docs/ARCHITECTURE.vi.md
@@ -217,6 +217,19 @@ iOS Simulator.
   lần dựng lại encoder, và một frame khác loại đến sau sẽ trả về `false` — đó là tín
   hiệu để dựng lại.
 
+- **Viewer Apple hiển thị video theo PTS trên một control timebase, và pacer không bao
+  giờ tin chính nó**: hiển thị mỗi frame ngay lúc nó đến khiến jitter Wi-Fi hiện ra
+  thành giật hình trong khi mọi con số độ trễ vẫn đẹp — nhịp không phải là độ trễ.
+  `VideoPacer` (core, test offline được) ánh xạ PTS của host sang giờ hiển thị local
+  theo đúng cách metric e2e làm — minimum theo cửa sổ của `arrival − pts` — cộng một
+  khoảng đệm ~33 ms để jitter được trả từ đó, và `VtDecoder` lái control timebase của
+  `AVSampleBufferDisplayLayer` theo nó, chỉ resync khi lệch quá 250 ms. Một cú nhảy pts
+  quá 2 s được đọc là stream mới chứ không phải jitter, nên ánh xạ được dựng lại thay
+  vì đứng hình suốt một cửa sổ. Vì không thể chứng minh từ đây rằng renderer tôn trọng
+  timebase ngoài trên mọi phiên bản OS, decoder tự canh lưng mình: một chuỗi frame bị
+  hàng đợi renderer đầy nuốt mất sẽ lật về display-immediately và flush — thà mất phần
+  mượt còn hơn mất hình.
+
 - **Audio là một khung một datagram, và mất thì không đuổi theo**: một khung Opus 20 ms
   ở 64 kbps đo được khoảng 160 byte, rộng nhất 209 byte, so với 1180 byte một datagram
   chứa được — nên đường audio không có packetizer, không FEC, không reassembler, không

--- a/platform/include/deskhubp/media/VtDecoder.h
+++ b/platform/include/deskhubp/media/VtDecoder.h
@@ -2,6 +2,7 @@
 #include <cstddef>
 #include <cstdint>
 
+#include "deskhub/control/VideoPacer.h"
 #include "deskhub/media/PresentCounters.h"
 #include "deskhub/media/VideoContract.h"
 #include <vector>
@@ -33,9 +34,27 @@ public:
         return counters_.lastRenderedPtsUs();
     }
 
+    uint32_t TakePresentDelayMs() {
+        return counters_.TakePresentDelayMs();
+    }
+
+    uint64_t lastRenderedAtUs() const {
+        return counters_.lastRenderedAtUs();
+    }
+
 private:
+    static constexpr uint32_t kPacedStallDrops = 30;
+
+    bool EnsurePacedTimebase(uint64_t ptsUs, uint64_t nowUs);
+    void DisablePacing();
+
     void* layer_ = nullptr;
     void* formatDesc_ = nullptr;
+    void* timebase_ = nullptr;
+    deskhub::VideoPacer pacer_;
+    bool timebaseRunning_ = false;
+    bool paceDisabled_ = false;
+    uint32_t pacedCongestionRun_ = 0;
     deskhub::media::PresentCounters counters_;
 
     uint8_t sps_[256] = {};
@@ -52,3 +71,5 @@ static_assert(deskhub::media::RenderCountingDecoder<VtDecoder>,
     "VtDecoder counts presented frames itself — the enqueue is async so Decode cannot count them");
 static_assert(deskhub::media::CongestionAwareDecoder<VtDecoder>,
     "VtDecoder must report frames swallowed by the display layer — that is where disp_drop comes from");
+static_assert(deskhub::media::PresentTimingDecoder<VtDecoder>,
+    "VtDecoder paces presentation, so e2e must be measured at the scheduled display time");

--- a/platform/src/media/VtDecoderApple.mm
+++ b/platform/src/media/VtDecoderApple.mm
@@ -55,10 +55,70 @@ void VtDecoder::Shutdown() {
     }
     if (layer_) {
         AVSampleBufferDisplayLayer* l = (__bridge AVSampleBufferDisplayLayer*)layer_;
+        if (timebase_) l.controlTimebase = nullptr;
         [l.sampleBufferRenderer flush];
         layer_ = nullptr;
     }
+    if (timebase_) {
+        CFRelease((CMTimebaseRef)timebase_);
+        timebase_ = nullptr;
+    }
+    pacer_.Reset();
+    timebaseRunning_ = false;
+    paceDisabled_ = false;
+    pacedCongestionRun_ = 0;
     spsLen_ = ppsLen_ = 0;
+}
+
+bool VtDecoder::EnsurePacedTimebase(uint64_t ptsUs, uint64_t nowUs) {
+    if (paceDisabled_) return false;
+    pacer_.ObserveArrival(ptsUs, nowUs);
+
+    AVSampleBufferDisplayLayer* l = (__bridge AVSampleBufferDisplayLayer*)layer_;
+    if (!timebase_) {
+        CMTimebaseRef tb = nullptr;
+        if (CMTimebaseCreateWithSourceClock(kCFAllocatorDefault, CMClockGetHostTimeClock(),
+                &tb) != noErr ||
+            !tb) {
+            LOGW("[Decoder] no control timebase — frames will display on arrival.");
+            paceDisabled_ = true;
+            return false;
+        }
+        timebase_ = (void*)tb;
+        l.controlTimebase = tb;
+    }
+
+    CMTimebaseRef tb = (CMTimebaseRef)timebase_;
+    const int64_t currentUs =
+        CMTimeConvertScale(CMTimebaseGetTime(tb), 1'000'000, kCMTimeRoundingMethod_Default)
+            .value;
+    if (!timebaseRunning_ || pacer_.NeedsResync(currentUs, nowUs)) {
+        const OSStatus timeSet =
+            CMTimebaseSetTime(tb, CMTimeMake(pacer_.DesiredTimebaseUs(nowUs), 1'000'000));
+        const OSStatus rateSet = CMTimebaseSetRate(tb, 1.0);
+        if (timeSet != noErr || rateSet != noErr) {
+            DisablePacing();
+            return false;
+        }
+        timebaseRunning_ = true;
+    }
+    return true;
+}
+
+void VtDecoder::DisablePacing() {
+    paceDisabled_ = true;
+    timebaseRunning_ = false;
+    if (layer_) {
+        AVSampleBufferDisplayLayer* l = (__bridge AVSampleBufferDisplayLayer*)layer_;
+        if (timebase_) l.controlTimebase = nullptr;
+        [l.sampleBufferRenderer flush];
+    }
+    if (timebase_) {
+        CFRelease((CMTimebaseRef)timebase_);
+        timebase_ = nullptr;
+    }
+    LOGW("[Decoder] paced frames were not being consumed — falling back to "
+         "display-immediately.");
 }
 
 bool VtDecoder::Decode(const uint8_t* nal, size_t len, uint64_t ptsUs) {
@@ -146,12 +206,16 @@ bool VtDecoder::Decode(const uint8_t* nal, size_t len, uint64_t ptsUs) {
         return false;
     }
 
-    if (CFArrayRef atts = CMSampleBufferGetSampleAttachmentsArray(sb, true)) {
-        if (CFArrayGetCount(atts) > 0) {
-            CFMutableDictionaryRef d0 =
-                (CFMutableDictionaryRef)CFArrayGetValueAtIndex(atts, 0);
-            CFDictionarySetValue(d0, kCMSampleAttachmentKey_DisplayImmediately,
-                kCFBooleanTrue);
+    const uint64_t nowUs = NowUs();
+    const bool paced = EnsurePacedTimebase(ptsUs, nowUs);
+    if (!paced) {
+        if (CFArrayRef atts = CMSampleBufferGetSampleAttachmentsArray(sb, true)) {
+            if (CFArrayGetCount(atts) > 0) {
+                CFMutableDictionaryRef d0 =
+                    (CFMutableDictionaryRef)CFArrayGetValueAtIndex(atts, 0);
+                CFDictionarySetValue(d0, kCMSampleAttachmentKey_DisplayImmediately,
+                    kCFBooleanTrue);
+            }
         }
     }
 
@@ -168,13 +232,17 @@ bool VtDecoder::Decode(const uint8_t* nal, size_t len, uint64_t ptsUs) {
 
     if (!r.isReadyForMoreMediaData) {
         counters_.CountCongestionDrop();
+        if (paced && ++pacedCongestionRun_ >= kPacedStallDrops) DisablePacing();
         CFRelease(sb);
         return true;
     }
+    pacedCongestionRun_ = 0;
 
     [r enqueueSampleBuffer:sb];
     CFRelease(sb);
 
-    counters_.FramePresented(ptsUs, NowUs());
+    const uint64_t shownUs = paced ? pacer_.DisplayTimeUs(ptsUs, nowUs) : nowUs;
+    counters_.FramePresented(ptsUs, shownUs);
+    if (paced) counters_.RecordPresentDelayMs(uint32_t((shownUs - nowUs) / 1000));
     return true;
 }

--- a/scripts/build-ffmpeg.sh
+++ b/scripts/build-ffmpeg.sh
@@ -10,7 +10,7 @@ STAMP="$PREFIX/.stamp"
 CONFIGURE_FLAGS=(
     --disable-everything
     --disable-programs --disable-doc --disable-network --disable-autodetect
-    --disable-avdevice --disable-avformat --disable-swscale --disable-swresample
+    --disable-avdevice --disable-avformat --disable-swresample
     --disable-avfilter
     --enable-decoder=h264
     --enable-hwaccel=h264_vaapi
@@ -30,7 +30,7 @@ command -v nasm >/dev/null 2>&1 || {
     exit 1
 }
 
-echo "[install] ffmpeg-min $FFMPEG_VERSION (h264 decoder + vaapi hwaccel only)..."
+echo "[install] ffmpeg-min $FFMPEG_VERSION (h264 decoder + vaapi hwaccel + swscale)..."
 BUILD="$PREFIX/src"
 rm -rf "$PREFIX"
 mkdir -p "$BUILD"


### PR DESCRIPTION
Testing from an iPhone against a Linux host showed janky video while every e2e number stayed low. The host log told the story: 0% loss, 8 ms RTT, but capture stuck at ~35–40 fps with a wildly uneven cadence. Three causes, three fixes:

## Host: encode off the capture thread (`505e06b`)

Encoding ran inside PipeWire's `process` callback, so a 23 ms encode capped capture at ~43 fps and every encode-time wobble became cadence jitter. Mapped frames are now copied once and handed to a dedicated encode thread through `FrameMailbox`, a latest-wins single-slot queue in `core/` (unit-tested). Dma-buf frames still encode inline — the compositor reuses their backing memory after the callback returns.

## Host: NVENC on the GPU that has the frames (`51d6530`)

On a desktop rendered by an NVIDIA GPU the compositor renegotiates screencast to shared memory, so every frame crossed the CPU to be encoded on the idle Intel iGPU at 23 ms a frame. `HwEncoder` now picks per rebuild: dma-buf → VA-API (zero-copy stays optimal), mapped → NVENC via the `nvenc-13.0` submodule headers the Windows client already uses (dlopen `libnvidia-encode`/`libcuda`, VA-API fallback). Measured end to end on an RTX 5070 Ti: 12 ms a frame including the swscale downscale, IDR + SPS/PPS with the zero-reorder rewrite verified against a live session.

## Client: pace Apple video by PTS (`793bfb3`)

Frames displayed the instant they arrived (`DisplayImmediately`), so arrival jitter went straight to the glass. `VideoPacer` (core, tested offline) maps host PTS to local display time from a windowed arrival floor plus a ~33 ms lead; `VtDecoder` drives the layer's control timebase from it and resyncs only past 250 ms. If a renderer ever refuses the external timebase, a run of unconsumed frames flips back to display-immediately — the failure mode costs smoothing, never the picture.

Docs: two new "Decisions worth remembering" entries (EN+VI), third-party notices updated for `libswscale` + the NVENC headers (EN+VI).

Verified: `make test` (new FrameMailbox + VideoPacer suites), `make lint`, `make lint-tidy`, coverage 97.8%/89.1% against the 90/80 gate, `make build-linux`, and a standalone NVENC smoke test on this machine's RTX 5070 Ti.