### PR TITLE
fix(windows): start the command-line client instead of dying in the loader

### DIFF
--- a/client/windows/cpp/CMakeLists.txt
+++ b/client/windows/cpp/CMakeLists.txt
@@ -56,4 +56,6 @@ target_link_libraries(deskhub_win_view PUBLIC deskhub_win_core comctl32)
 deskhub_target_warnings(deskhub_win_view)
 if(MSVC)
     target_compile_options(deskhub_win_view PRIVATE /sdl)
+    target_link_options(deskhub_win_view INTERFACE
+        "/MANIFESTDEPENDENCY:type='win32' name='Microsoft.Windows.Common-Controls' version='6.0.0.0' processorArchitecture='*' publicKeyToken='6595b64144ccf1df' language='*'")
 endif()

--- a/client/windows/win32/main.cpp
+++ b/client/windows/win32/main.cpp
@@ -9,11 +9,6 @@
 #include "capture/ScreenCapture.h"
 #include "deskhubp/diag/LogFile.h"
 
-#pragma comment(linker,                                                              \
-    "/manifestdependency:\"type='win32' name='Microsoft.Windows.Common-Controls' "   \
-    "version='6.0.0.0' processorArchitecture='*' publicKeyToken='6595b64144ccf1df' " \
-    "language='*'\"")
-
 int APIENTRY wWinMain(HINSTANCE, HINSTANCE, PWSTR, int) {
     deskhubp::StartProcessLog();
     SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);


### PR DESCRIPTION
`build-desktop / windows` failed at `Smoke the command-line client` with exit 127 and no output. Two diagnostic runs on this branch (now removed) showed the real cause:

- the process dies in the loader with `0xC0000138` (`STATUS_ORDINAL_NOT_FOUND`)
- `dumpbin /imports` shows exactly one comctl32 import, and it is by ordinal: `#345`
- Media Foundation was a red herring — `mfplat`, `mfreadwrite`, `mfcore` and `RTWorkQ` all `LoadLibraryW` fine on the runner

comctl32 ordinal 345 is `TaskDialogIndirect`, which exists only in version 6. `Viewer.cpp:213` calls it, and `deskhub-cli` links `Viewer.cpp` through `deskhub_win_view` — but the `Microsoft.Windows.Common-Controls 6.0.0.0` manifest dependency lived in `client/windows/win32/main.cpp`, which only `Deskhub.exe` compiles. The CLI therefore bound comctl32 5.82 from System32 and never reached `main()`.

This is not CI-specific: the published `deskhub-cli.exe` would fail to start on any Windows machine.

The manifest dependency now rides on `deskhub_win_view` as an `INTERFACE` link option, so any executable linking the viewer inherits it, and the duplicate pragma is gone from `main.cpp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)