### PR TITLE
feat: ship deskhub-cli for macOS, Windows and Linux on the Releases page

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -1,0 +1,230 @@
+name: build-cli
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  windows:
+    runs-on: windows-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: recursive
+
+      - name: Setup MSVC environment
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+        with:
+          arch: x64
+
+      - name: Install Ninja + NASM
+        run: choco install ninja nasm -y
+
+      - name: Cache quiche
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            third_party/quiche/include
+            third_party/quiche/x86_64-pc-windows-msvc
+          key: quiche-windows-${{ hashFiles('scripts/build-quiche.sh') }}
+
+      - name: Build quiche (static QUIC + TLS)
+        shell: bash
+        run: |
+          scripts/build-quiche.sh windows 2>&1 | tee quiche-build.log ||
+            { grep -iE "error|LNK[0-9]|panicked" quiche-build.log | tail -30 | sed 's/^/::error::/' || true
+              tail -15 quiche-build.log | sed 's/^/::error::/' || true
+              exit 1; }
+
+      - name: Cache opus
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            third_party/opus/include
+            third_party/opus/x86_64-pc-windows-msvc
+          key: opus-windows-${{ hashFiles('scripts/build-opus.sh') }}
+
+      - name: Build opus (static audio codec)
+        shell: bash
+        run: |
+          scripts/build-opus.sh windows 2>&1 | tee opus-build.log ||
+            { grep -iE "error|LNK[0-9]" opus-build.log | tail -30 | sed 's/^/::error::/' || true
+              tail -15 opus-build.log | sed 's/^/::error::/' || true
+              exit 1; }
+
+      - name: Configure without the desktop app, which would fetch wxWidgets
+        run: cmake --preset x64-release -DDESKHUB_CLI=ON -DDESKHUB_WINDOWS_APP=OFF
+
+      - name: Build the command-line client
+        shell: bash
+        run: |
+          cmake --build --preset x64-release --target deskhub_cli 2>&1 | tee cli-build.log ||
+            { grep -iE "error|LNK[0-9]" cli-build.log | tail -40 | sed 's/^/::error::/' || true
+              exit 1; }
+
+      - name: Assert the exe needs no redistributable
+        shell: pwsh
+        run: |
+          $exe = 'out/build/x64-release/client/cli/deskhub-cli.exe'
+          $deps = dumpbin /dependents $exe
+          $deps
+          $bad = $deps | Select-String -Pattern 'VCRUNTIME|MSVCP\d|MSVCR\d'
+          if ($bad) {
+            Write-Output "::error::$exe needs the Visual C++ Redistributable - the release is supposed to be a single self-contained exe"
+            exit 1
+          }
+          Write-Output "OK - the MSVC runtime is linked statically."
+
+      - name: Smoke the command-line client
+        shell: bash
+        run: scripts/cli-smoke.sh out/build/x64-release/client/cli/deskhub-cli.exe
+
+      - name: Upload the command-line client
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: deskhub-cli-windows
+          path: out/build/x64-release/client/cli/deskhub-cli.exe
+          retention-days: 14
+          if-no-files-found: error
+
+  macos:
+    runs-on: macos-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Cache quiche
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            third_party/quiche/include
+            third_party/quiche/aarch64-apple-darwin
+            third_party/quiche/x86_64-apple-darwin
+            third_party/quiche/macos-universal
+          key: quiche-macos-${{ hashFiles('scripts/build-quiche.sh') }}
+
+      - name: Build quiche (static QUIC + TLS)
+        run: |
+          scripts/build-quiche.sh aarch64-apple-darwin x86_64-apple-darwin
+          test -f third_party/quiche/macos-universal/libquiche.a
+
+      - name: Cache opus
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            third_party/opus/include
+            third_party/opus/aarch64-apple-darwin
+            third_party/opus/x86_64-apple-darwin
+            third_party/opus/macos-universal
+          key: opus-macos-${{ hashFiles('scripts/build-opus.sh') }}
+
+      - name: Build opus (static audio codec)
+        run: |
+          scripts/build-opus.sh aarch64-apple-darwin x86_64-apple-darwin
+          test -f third_party/opus/macos-universal/libopus.a
+
+      - name: Configure
+        run: >
+          cmake --preset arm64-release -DDESKHUB_CLI=ON
+          -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64"
+
+      - name: Build the command-line client
+        run: cmake --build --preset arm64-release --target deskhub_cli
+
+      - name: Assert one binary carries both architectures
+        run: |
+          bin=out/build/arm64-release/client/cli/deskhub-cli
+          archs=$(lipo -archs "$bin")
+          echo "$bin: $archs"
+          for want in arm64 x86_64; do
+            case " $archs " in
+              *" $want "*) ;;
+              *) echo "::error::$bin has no $want slice - Intel Macs would not run it"; exit 1 ;;
+            esac
+          done
+
+      - name: Smoke the command-line client
+        run: scripts/cli-smoke.sh out/build/arm64-release/client/cli/deskhub-cli
+
+      - name: Upload the command-line client
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: deskhub-cli-macos
+          path: out/build/arm64-release/client/cli/deskhub-cli
+          retention-days: 14
+          if-no-files-found: error
+
+  linux:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install build dependencies, none of them a GUI toolkit
+        run: >
+          scripts/apt-install.sh ninja-build pkg-config nasm
+          libglib2.0-dev libepoxy-dev libegl-dev libgles-dev
+          libdrm-dev libva-dev libpipewire-0.3-dev libspa-0.2-dev
+          libx11-dev libxfixes-dev
+
+      - name: Cache minimal FFmpeg
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: third_party/ffmpeg-min
+          key: ffmpeg-min-ubuntu-22.04-${{ hashFiles('scripts/build-ffmpeg.sh') }}
+
+      - name: Build minimal FFmpeg (static, h264 decode only)
+        run: scripts/build-ffmpeg.sh
+
+      - name: Cache quiche
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            third_party/quiche/include
+            third_party/quiche/x86_64-unknown-linux-gnu
+          key: quiche-ubuntu-22.04-${{ hashFiles('scripts/build-quiche.sh') }}
+
+      - name: Build quiche (static QUIC + TLS)
+        run: scripts/build-quiche.sh host
+
+      - name: Cache opus
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            third_party/opus/include
+            third_party/opus/x86_64-unknown-linux-gnu
+          key: opus-ubuntu-22.04-${{ hashFiles('scripts/build-opus.sh') }}
+
+      - name: Build opus (static audio codec)
+        run: scripts/build-opus.sh host
+
+      - name: Configure without the desktop app, which would need GTK
+        run: cmake --preset x64-release -DDESKHUB_CLI=ON -DDESKHUB_LINUX_APP=OFF
+
+      - name: Build the command-line client
+        run: cmake --build --preset x64-release --target deskhub_cli
+
+      - name: Assert no dynamic FFmpeg dependency
+        run: |
+          bin=out/build/x64-release/client/cli/deskhub-cli
+          if readelf -d "$bin" | grep -q 'NEEDED.*libav'; then
+            echo "::error::$bin links libav* dynamically — the release would not start on newer Ubuntu"
+            readelf -d "$bin" | grep NEEDED
+            exit 1
+          fi
+          echo "OK — FFmpeg is linked statically. Dynamic dependencies:"
+          readelf -d "$bin" | grep NEEDED
+
+      - name: Smoke the command-line client
+        run: scripts/cli-smoke.sh out/build/x64-release/client/cli/deskhub-cli
+
+      - name: Upload the command-line client
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: deskhub-cli-linux
+          path: out/build/x64-release/client/cli/deskhub-cli
+          retention-days: 14
+          if-no-files-found: error

--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -162,6 +162,8 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: recursive
 
       - name: Install build dependencies, none of them a GUI toolkit
         run: >

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -107,6 +107,73 @@ jobs:
           retention-days: 14
           if-no-files-found: error
 
+  macos-cli:
+    runs-on: macos-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Cache quiche
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            third_party/quiche/include
+            third_party/quiche/aarch64-apple-darwin
+            third_party/quiche/x86_64-apple-darwin
+            third_party/quiche/macos-universal
+          key: quiche-macos-${{ hashFiles('scripts/build-quiche.sh') }}
+
+      - name: Build quiche (static QUIC + TLS)
+        run: |
+          scripts/build-quiche.sh aarch64-apple-darwin x86_64-apple-darwin
+          test -f third_party/quiche/macos-universal/libquiche.a
+
+      - name: Cache opus
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            third_party/opus/include
+            third_party/opus/aarch64-apple-darwin
+            third_party/opus/x86_64-apple-darwin
+            third_party/opus/macos-universal
+          key: opus-macos-${{ hashFiles('scripts/build-opus.sh') }}
+
+      - name: Build opus (static audio codec)
+        run: |
+          scripts/build-opus.sh aarch64-apple-darwin x86_64-apple-darwin
+          test -f third_party/opus/macos-universal/libopus.a
+
+      - name: Configure
+        run: >
+          cmake --preset arm64-release -DDESKHUB_CLI=ON
+          -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64"
+
+      - name: Build the command-line client
+        run: cmake --build --preset arm64-release --target deskhub_cli
+
+      - name: Assert one binary carries both architectures
+        run: |
+          bin=out/build/arm64-release/client/cli/deskhub-cli
+          archs=$(lipo -archs "$bin")
+          echo "$bin: $archs"
+          for want in arm64 x86_64; do
+            case " $archs " in
+              *" $want "*) ;;
+              *) echo "::error::$bin has no $want slice - Intel Macs would not run it"; exit 1 ;;
+            esac
+          done
+
+      - name: Smoke the command-line client
+        run: scripts/cli-smoke.sh out/build/arm64-release/client/cli/deskhub-cli
+
+      - name: Upload the command-line client
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: deskhub-cli-macos
+          path: out/build/arm64-release/client/cli/deskhub-cli
+          retention-days: 14
+          if-no-files-found: error
+
   linux:
     strategy:
       fail-fast: false

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -62,7 +62,7 @@ jobs:
               exit 1; }
 
       - name: Configure
-        run: cmake --preset x64-release -DDESKHUB_CLI=ON
+        run: cmake --preset x64-release
 
       - name: Build the Windows app
         shell: bash
@@ -71,106 +71,23 @@ jobs:
             { grep -iE "error|LNK[0-9]" app-build.log | tail -40 | sed 's/^/::error::/' || true
               exit 1; }
 
-      - name: Assert neither exe needs a redistributable
+      - name: Assert the exe needs no redistributable
         shell: pwsh
         run: |
-          $exes = @($env:APP_EXE, 'out/build/x64-release/client/cli/deskhub-cli.exe')
-          foreach ($exe in $exes) {
-            Write-Output "== $exe"
-            $deps = dumpbin /dependents $exe
-            $deps
-            $bad = $deps | Select-String -Pattern 'VCRUNTIME|MSVCP\d|MSVCR\d'
-            if ($bad) {
-              Write-Output "::error::$exe needs the Visual C++ Redistributable - the release is supposed to be a single self-contained exe"
-              exit 1
-            }
+          $deps = dumpbin /dependents $env:APP_EXE
+          $deps
+          $bad = $deps | Select-String -Pattern 'VCRUNTIME|MSVCP\d|MSVCR\d'
+          if ($bad) {
+            Write-Output "::error::$env:APP_EXE needs the Visual C++ Redistributable - the release is supposed to be a single self-contained exe"
+            exit 1
           }
           Write-Output "OK - the MSVC runtime is linked statically."
-
-      - name: Smoke the command-line client
-        shell: bash
-        run: scripts/cli-smoke.sh out/build/x64-release/client/cli/deskhub-cli.exe
 
       - name: Upload app
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: deskhub-windows
           path: ${{ env.APP_EXE }}
-          retention-days: 14
-          if-no-files-found: error
-
-      - name: Upload the command-line client
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: deskhub-cli-windows
-          path: out/build/x64-release/client/cli/deskhub-cli.exe
-          retention-days: 14
-          if-no-files-found: error
-
-  macos-cli:
-    runs-on: macos-latest
-    timeout-minutes: 45
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: Cache quiche
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: |
-            third_party/quiche/include
-            third_party/quiche/aarch64-apple-darwin
-            third_party/quiche/x86_64-apple-darwin
-            third_party/quiche/macos-universal
-          key: quiche-macos-${{ hashFiles('scripts/build-quiche.sh') }}
-
-      - name: Build quiche (static QUIC + TLS)
-        run: |
-          scripts/build-quiche.sh aarch64-apple-darwin x86_64-apple-darwin
-          test -f third_party/quiche/macos-universal/libquiche.a
-
-      - name: Cache opus
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: |
-            third_party/opus/include
-            third_party/opus/aarch64-apple-darwin
-            third_party/opus/x86_64-apple-darwin
-            third_party/opus/macos-universal
-          key: opus-macos-${{ hashFiles('scripts/build-opus.sh') }}
-
-      - name: Build opus (static audio codec)
-        run: |
-          scripts/build-opus.sh aarch64-apple-darwin x86_64-apple-darwin
-          test -f third_party/opus/macos-universal/libopus.a
-
-      - name: Configure
-        run: >
-          cmake --preset arm64-release -DDESKHUB_CLI=ON
-          -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64"
-
-      - name: Build the command-line client
-        run: cmake --build --preset arm64-release --target deskhub_cli
-
-      - name: Assert one binary carries both architectures
-        run: |
-          bin=out/build/arm64-release/client/cli/deskhub-cli
-          archs=$(lipo -archs "$bin")
-          echo "$bin: $archs"
-          for want in arm64 x86_64; do
-            case " $archs " in
-              *" $want "*) ;;
-              *) echo "::error::$bin has no $want slice - Intel Macs would not run it"; exit 1 ;;
-            esac
-          done
-
-      - name: Smoke the command-line client
-        run: scripts/cli-smoke.sh out/build/arm64-release/client/cli/deskhub-cli
-
-      - name: Upload the command-line client
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: deskhub-cli-macos
-          path: out/build/arm64-release/client/cli/deskhub-cli
           retention-days: 14
           if-no-files-found: error
 
@@ -240,11 +157,8 @@ jobs:
       - name: Build the Ubuntu app (make release-linux)
         run: make release-linux
 
-      - name: Build the command-line client (make release-cli)
+      - name: Build the command-line client the deb and the rpm ship
         run: make release-cli
-
-      - name: Smoke the command-line client
-        run: scripts/cli-smoke.sh out/build/x64-release/client/cli/deskhub-cli
 
       - name: Assert no dynamic FFmpeg dependency
         run: |
@@ -263,15 +177,6 @@ jobs:
         with:
           name: deskhub-linux
           path: out/build/x64-release/client/linux/deskhub
-          retention-days: 14
-          if-no-files-found: error
-
-      - name: Upload the command-line client
-        if: matrix.release
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: deskhub-cli-linux
-          path: out/build/x64-release/client/cli/deskhub-cli
           retention-days: 14
           if-no-files-found: error
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ jobs:
   build-desktop:
     uses: ./.github/workflows/build-desktop.yml
 
+  build-cli:
+    uses: ./.github/workflows/build-cli.yml
+
   build-mobile:
     uses: ./.github/workflows/build-mobile.yml
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,6 +63,8 @@ jobs:
           mv dist/deskhub-cli-windows/deskhub-cli.exe "out/deskhub-cli-${GITHUB_REF_NAME}-windows.exe"
           mv dist/deskhub-cli-linux/deskhub-cli "out/deskhub-cli-${GITHUB_REF_NAME}-linux-x86_64"
           chmod +x "out/deskhub-cli-${GITHUB_REF_NAME}-linux-x86_64"
+          mv dist/deskhub-cli-macos/deskhub-cli "out/deskhub-cli-${GITHUB_REF_NAME}-macos"
+          chmod +x "out/deskhub-cli-${GITHUB_REF_NAME}-macos"
           mv dist/deskhub-linux-deb/deskhub_*.deb "out/deskhub-${GITHUB_REF_NAME}-amd64.deb"
           mv dist/deskhub-linux-rpm/deskhub-*.rpm "out/deskhub-${GITHUB_REF_NAME}-x86_64.rpm"
 
@@ -93,6 +95,7 @@ jobs:
             out/deskhub-${{ github.ref_name }}-x86_64.rpm
             out/deskhub-cli-${{ github.ref_name }}-windows.exe
             out/deskhub-cli-${{ github.ref_name }}-linux-x86_64
+            out/deskhub-cli-${{ github.ref_name }}-macos
           body_path: out/release-notes.md
 
   release-ios:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,6 +60,9 @@ jobs:
           mv dist/deskhub-windows/Deskhub.exe "out/deskhub-${GITHUB_REF_NAME}-windows.exe"
           mv dist/deskhub-linux/deskhub "out/deskhub-${GITHUB_REF_NAME}-linux-x86_64"
           chmod +x "out/deskhub-${GITHUB_REF_NAME}-linux-x86_64"
+          mv dist/deskhub-cli-windows/deskhub-cli.exe "out/deskhub-cli-${GITHUB_REF_NAME}-windows.exe"
+          mv dist/deskhub-cli-linux/deskhub-cli "out/deskhub-cli-${GITHUB_REF_NAME}-linux-x86_64"
+          chmod +x "out/deskhub-cli-${GITHUB_REF_NAME}-linux-x86_64"
           mv dist/deskhub-linux-deb/deskhub_*.deb "out/deskhub-${GITHUB_REF_NAME}-amd64.deb"
           mv dist/deskhub-linux-rpm/deskhub-*.rpm "out/deskhub-${GITHUB_REF_NAME}-x86_64.rpm"
 
@@ -70,6 +73,8 @@ jobs:
           ---
 
           📦 **Installing** — every platform, one page: [INSTALL.md](https://github.com/manhpham90vn/Deskhub/blob/main/docs/INSTALL.md).
+          The `deskhub-cli-*` files are the same client without a window, for a script or an SSH session;
+          the deb and the rpm already install it as `deskhub-cli`.
           The macOS dmg and the Android apk are attached by their own jobs and may show up a few minutes later;
           iOS ships through [TestFlight](https://testflight.apple.com/join/7qY7wgpd).
 
@@ -86,6 +91,8 @@ jobs:
             out/deskhub-${{ github.ref_name }}-linux-x86_64
             out/deskhub-${{ github.ref_name }}-amd64.deb
             out/deskhub-${{ github.ref_name }}-x86_64.rpm
+            out/deskhub-cli-${{ github.ref_name }}-windows.exe
+            out/deskhub-cli-${{ github.ref_name }}-linux-x86_64
           body_path: out/release-notes.md
 
   release-ios:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,8 +37,12 @@ jobs:
     with:
       for_release: true
 
+  build-cli:
+    needs: verify-tag
+    uses: ./.github/workflows/build-cli.yml
+
   github-release:
-    needs: build-desktop
+    needs: [build-desktop, build-cli]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -196,14 +196,19 @@ the same as the app's, so the two agree.
 | Platform | File |
 | --- | --- |
 | 🪟 Windows | `deskhub-cli-v*-windows.exe` — download and run it, no installer |
+| 🍎 macOS | `deskhub-cli-v*-macos` — one binary for Apple Silicon and Intel |
 | 🐧 Linux | `deskhub-cli-v*-linux-x86_64`, or already there if you installed the deb or the rpm |
 
-It shares a screen through the same portal and VA-API driver the app needs, and relies on
-the same `/dev/uinput` rule for remote input, so everything under [Linux](#-linux) applies
-to it too.
+The macOS and Linux files arrive without the executable bit, so `chmod +x` them once.
+Neither is signed or notarized the way the dmg is: on macOS the first run needs
+`xattr -d com.apple.quarantine deskhub-cli-v*-macos`, or *Open Anyway* in System Settings
+→ Privacy & Security.
 
-macOS has no prebuilt command-line client yet — build it yourself with `make release-cli`
-([BUILD.md](BUILD.md)).
+On Linux it shares a screen through the same portal and VA-API driver the app needs, and
+relies on the same `/dev/uinput` rule for remote input, so everything under
+[Linux](#-linux) applies to it too. On macOS it shares a screen and opens shells, but it
+cannot *watch* one — `connect` needs a window layer the command-line build does not have,
+and says so; use the app for that.
 
 ---
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -20,6 +20,9 @@ distributed by TestFlight and Google Play.
 | 🤖 Android | `deskhub-v*-android.apk` | Install the apk, or join the Play beta |
 | 📱 iOS | — | [TestFlight](https://testflight.apple.com/join/7qY7wgpd) |
 
+There is also `deskhub-cli`, the same client with no window of its own — see
+[Command line](#-command-line).
+
 ---
 
 ## 🪟 Windows
@@ -65,10 +68,8 @@ remote input works right after install, with no group change and no re-login. Th
 portable binary runs on any x86_64 distro with glibc 2.35+ (Ubuntu 22.04, Fedora 36,
 openSUSE 15.5, any current Arch).
 
-The deb and the rpm also install `deskhub-cli`, the same client without a window of its
-own: it shares a screen, opens a remote shell and drives a host from a script or over
-SSH. Run `deskhub-cli help` for the list. Everything it reads and writes — settings,
-paired machines, trusted host keys — is the same as the app's, so the two agree.
+The deb and the rpm also install `deskhub-cli` as `/usr/bin/deskhub-cli` — see
+[Command line](#-command-line) below.
 
 **To share this machine's screen**, three more things must be in place.
 
@@ -182,6 +183,27 @@ An ipa cannot be sideloaded, so the beta runs through TestFlight:
 
 Like Android, an iPhone or iPad hosts view-only — no mobile OS lets an app inject input
 into the device it runs on.
+
+---
+
+## 💻 Command line
+
+`deskhub-cli` is the same client without a window of its own: it shares a screen, opens a
+remote shell and drives a host from a script or over SSH. Run `deskhub-cli help` for the
+list. Everything it reads and writes — settings, paired machines, trusted host keys — is
+the same as the app's, so the two agree.
+
+| Platform | File |
+| --- | --- |
+| 🪟 Windows | `deskhub-cli-v*-windows.exe` — download and run it, no installer |
+| 🐧 Linux | `deskhub-cli-v*-linux-x86_64`, or already there if you installed the deb or the rpm |
+
+It shares a screen through the same portal and VA-API driver the app needs, and relies on
+the same `/dev/uinput` rule for remote input, so everything under [Linux](#-linux) applies
+to it too.
+
+macOS has no prebuilt command-line client yet — build it yourself with `make release-cli`
+([BUILD.md](BUILD.md)).
 
 ---
 

--- a/docs/INSTALL.vi.md
+++ b/docs/INSTALL.vi.md
@@ -24,6 +24,9 @@ Mọi file tải về đều nằm ở
 | 🤖 Android | `deskhub-v*-android.apk` | Cài file apk, hoặc tham gia bản beta trên Play |
 | 📱 iOS | — | [TestFlight](https://testflight.apple.com/join/7qY7wgpd) |
 
+Ngoài ra còn có `deskhub-cli`, vẫn là client đó nhưng không có cửa sổ riêng — xem
+[Dòng lệnh](#-dòng-lệnh).
+
 ---
 
 ## 🪟 Windows
@@ -68,10 +71,8 @@ chạy được ngay sau khi cài, không cần đổi nhóm người dùng, kh�
 chạy thẳng chạy được trên mọi bản phân phối x86_64 có glibc 2.35+ (Ubuntu 22.04, Fedora
 36, openSUSE 15.5, Arch hiện hành).
 
-File deb và rpm cũng cài kèm `deskhub-cli`, vẫn là client đó nhưng không có cửa sổ riêng:
-nó chia sẻ màn hình, mở shell từ xa và điều khiển host từ script hay qua SSH. Chạy
-`deskhub-cli help` để xem danh sách lệnh. Mọi thứ nó đọc và ghi — cấu hình, máy đã ghép
-đôi, khoá host đã tin — đều dùng chung với app, nên hai bên luôn khớp nhau.
+File deb và rpm cũng cài kèm `deskhub-cli` vào `/usr/bin/deskhub-cli` — xem
+[Dòng lệnh](#-dòng-lệnh) bên dưới.
 
 **Để chia sẻ màn hình của máy này**, cần thêm ba thứ nữa.
 
@@ -184,6 +185,27 @@ File ipa không sideload được, nên bản beta chạy qua TestFlight:
 
 Giống Android, iPhone hay iPad ở vai host chỉ chia sẻ để xem — không hệ điều hành di động
 nào cho phép một app bơm thao tác điều khiển vào chính thiết bị nó đang chạy.
+
+---
+
+## 💻 Dòng lệnh
+
+`deskhub-cli` vẫn là client đó nhưng không có cửa sổ riêng: nó chia sẻ màn hình, mở shell
+từ xa và điều khiển host từ script hay qua SSH. Chạy `deskhub-cli help` để xem danh sách
+lệnh. Mọi thứ nó đọc và ghi — cấu hình, máy đã ghép đôi, khoá host đã tin — đều dùng chung
+với app, nên hai bên luôn khớp nhau.
+
+| Nền tảng | File |
+| --- | --- |
+| 🪟 Windows | `deskhub-cli-v*-windows.exe` — tải về rồi chạy, không cần trình cài đặt |
+| 🐧 Linux | `deskhub-cli-v*-linux-x86_64`, hoặc đã có sẵn nếu bạn cài bản deb hay rpm |
+
+Nó chia sẻ màn hình qua đúng portal và driver VA-API mà app cần, và cũng dựa vào luật
+`/dev/uinput` đó để điều khiển từ xa, nên mọi thứ nói ở phần [Linux](#-linux) đều áp dụng
+cho nó.
+
+macOS chưa có bản dựng sẵn cho dòng lệnh — bạn tự build bằng `make release-cli`
+([BUILD.vi.md](BUILD.vi.md)).
 
 ---
 

--- a/docs/INSTALL.vi.md
+++ b/docs/INSTALL.vi.md
@@ -198,14 +198,19 @@ với app, nên hai bên luôn khớp nhau.
 | Nền tảng | File |
 | --- | --- |
 | 🪟 Windows | `deskhub-cli-v*-windows.exe` — tải về rồi chạy, không cần trình cài đặt |
+| 🍎 macOS | `deskhub-cli-v*-macos` — một file chạy được cả Apple Silicon lẫn Intel |
 | 🐧 Linux | `deskhub-cli-v*-linux-x86_64`, hoặc đã có sẵn nếu bạn cài bản deb hay rpm |
 
-Nó chia sẻ màn hình qua đúng portal và driver VA-API mà app cần, và cũng dựa vào luật
-`/dev/uinput` đó để điều khiển từ xa, nên mọi thứ nói ở phần [Linux](#-linux) đều áp dụng
-cho nó.
+Hai file macOS và Linux tải về chưa có quyền thực thi, nên `chmod +x` một lần. Cả hai đều
+không được ký và công chứng như file dmg: trên macOS lần chạy đầu cần
+`xattr -d com.apple.quarantine deskhub-cli-v*-macos`, hoặc bấm *Open Anyway* trong System
+Settings → Privacy & Security.
 
-macOS chưa có bản dựng sẵn cho dòng lệnh — bạn tự build bằng `make release-cli`
-([BUILD.vi.md](BUILD.vi.md)).
+Trên Linux nó chia sẻ màn hình qua đúng portal và driver VA-API mà app cần, và cũng dựa
+vào luật `/dev/uinput` đó để điều khiển từ xa, nên mọi thứ nói ở phần [Linux](#-linux) đều
+áp dụng cho nó. Trên macOS nó chia sẻ màn hình và mở shell được, nhưng không *xem* được
+màn hình máy khác — lệnh `connect` cần một lớp cửa sổ mà bản dòng lệnh không có, và nó báo
+rõ như vậy; muốn xem thì dùng app.
 
 ---
 

--- a/scripts/cli-smoke.sh
+++ b/scripts/cli-smoke.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 CLI=${1:-out/build/x64-debug/client/cli/deskhub-cli}
 PORT=${DESKHUB_SMOKE_PORT:-47989}
 PASSCODE=0417
-WORK=$(mktemp -d)
+WORK=$(mktemp -d "${TMPDIR:-/tmp}/deskhub-cli-smoke.XXXXXX")
 trap 'rm -rf "$WORK"' EXIT
 
 if [ ! -x "$CLI" ]; then


### PR DESCRIPTION
`deskhub-cli` was built for Windows and Linux and smoke-tested on both, but the standalone binaries never left the workflow artifacts — only the Linux deb and rpm carried it, so Windows users had no way to get it. macOS never built it, even though `CMakeLists.txt` has claimed support since the CLI landed.

### `build-cli.yml` — new, reusable

The CLI used to ride along inside the desktop jobs, which meant configuring wxWidgets on Windows and GTK on Linux to produce a binary that links neither. It now has its own workflow with one job per desktop system, each configured with the app switched **off** (`-DDESKHUB_WINDOWS_APP=OFF` / `-DDESKHUB_LINUX_APP=OFF`), and the smoke test living next to the build it exercises:

| Job | Gate beyond the smoke test |
| --- | --- |
| windows | `dumpbin /dependents` — no VC++ redistributable |
| macos | `lipo -archs` — both arm64 and x86_64 slices present |
| linux | `readelf -d` — no dynamic `libav*` |

Cache keys are shared with the existing jobs (`quiche-windows-*`, `quiche-macos-*`, `quiche-ubuntu-22.04-*` …), so nothing is rebuilt that another job already built.

`build-desktop.yml` still builds the Linux CLI: `stage-linux-pkgroot.sh:21` reads it out of the same tree to put it in the deb and the rpm. That one duplicate compile is deliberate.

### macOS

First time this has ever been built. The universal binary and the **full** smoke test — a real host sharing a shell over loopback, a viewer connecting to it, a command running in the remote shell — both pass:

```
out/build/arm64-release/client/cli/deskhub-cli: x86_64 arm64
== a shell-only host, and a viewer that talks to it
cli-smoke: OK
```

### `deploy.yml`

Attaches `deskhub-cli-<tag>-{windows.exe,linux-x86_64,macos}` to the release, and the notes say what they are. The `mv` calls are deliberately unguarded: drop an upload step and the deploy fails instead of quietly publishing a release with a file missing.

### `cli-smoke.sh`

`mktemp -d` with no template is a usage error on BSD, so the macOS job would have died on line 7.

### Docs

`INSTALL.md` and `INSTALL.vi.md` get a Command line section: the three files, `chmod +x`, the quarantine attribute macOS needs on an unsigned binary, and the fact that `connect` reports itself unsupported on the macOS CLI (per `BUILD.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)