### PR TITLE
Connection status, ping and auto-reconnect in every client

### DIFF
--- a/client/android/app/src/main/cpp/JniBridge.cpp
+++ b/client/android/app/src/main/cpp/JniBridge.cpp
@@ -18,9 +18,14 @@
 #include "deskhubp/ffi/SendFfi.h"
 
 static_assert(DHPhaseIdle == 0 && DHPhaseConnecting == 1 && DHPhaseStreaming == 2 &&
-              DHPhaseEnded == 3);
+              DHPhaseEnded == 3 && DHPhaseReattaching == 5);
 static_assert(DHStrClientIpPrompt == 3 && DHStrQueryingSources == 12 &&
               DHStrInvalidAddressHint == 17 && DHStrSessionEnded == 18);
+static_assert(DHStrDisconnectButton == 153 && DHStrLinkQualityGood == 154 &&
+              DHStrLinkQualityFair == 155 && DHStrLinkQualityPoor == 156 &&
+              DHStrLinkNoReading == 157 && DHStrLinkReattaching == 158);
+static_assert(DHLinkQualityUnknown == 0 && DHLinkQualityGood == 1 && DHLinkQualityFair == 2 &&
+              DHLinkQualityPoor == 3);
 static_assert(int32_t(deskhub::MouseButton::Left) == 1 &&
               int32_t(deskhub::MouseButton::Right) == 2);
 
@@ -771,6 +776,25 @@ Java_com_deskhub_app_NativeClient_nativeSnapshot(JNIEnv* env, jobject) {
     env->DeleteLocalRef(endReason);
     env->DeleteLocalRef(statusLine);
     return out;
+}
+
+JNIEXPORT jintArray JNICALL
+Java_com_deskhub_app_NativeClient_nativeLinkHealth(JNIEnv* env, jobject) {
+    DHLinkHealth health{};
+    dh_screen_link_health(g_session, &health);
+    const jint out[4] = {health.haveRtt ? 1 : 0, jint(health.rttMs), jint(health.lossPct),
+        jint(health.quality)};
+    jintArray arr = env->NewIntArray(4);
+    if (arr) env->SetIntArrayRegion(arr, 0, 4, out);
+    return arr;
+}
+
+JNIEXPORT jstring JNICALL
+Java_com_deskhub_app_NativeClient_nativeLinkPingText(JNIEnv* env, jobject, jboolean haveRtt,
+    jint rttMs) {
+    char buf[32];
+    dh_link_ping_text(haveRtt == JNI_TRUE, uint32_t(rttMs), buf, int(sizeof(buf)));
+    return env->NewStringUTF(buf);
 }
 
 JNIEXPORT jint JNICALL

--- a/client/android/app/src/main/java/com/deskhub/app/NativeClient.kt
+++ b/client/android/app/src/main/java/com/deskhub/app/NativeClient.kt
@@ -16,6 +16,7 @@ object NativeClient {
     const val PHASE_IDLE = 0
     const val PHASE_STREAMING = 2
     const val PHASE_ENDED = 3
+    const val PHASE_REATTACHING = 5
 
     init {
         System.loadLibrary("deskhub")
@@ -124,6 +125,12 @@ object NativeClient {
     const val STR_TRANSFER_BLOCKS_SCREEN_NOTE = 148
     const val STR_TRANSFER_ARRIVED_TITLE = 149
     const val STR_TRANSFER_STOP_TAKING_BUTTON = 150
+    const val STR_DISCONNECT_BUTTON = 153
+    const val STR_LINK_QUALITY_GOOD = 154
+    const val STR_LINK_QUALITY_FAIR = 155
+    const val STR_LINK_QUALITY_POOR = 156
+    const val STR_LINK_NO_READING = 157
+    const val STR_LINK_REATTACHING = 158
 
     private external fun nativeString(id: Int): String
 
@@ -832,6 +839,33 @@ object NativeClient {
     )
 
     external fun nativeSnapshot(): Snapshot?
+
+    const val LINK_QUALITY_UNKNOWN = 0
+    const val LINK_QUALITY_GOOD = 1
+    const val LINK_QUALITY_FAIR = 2
+    const val LINK_QUALITY_POOR = 3
+
+    data class LinkHealth(
+        val haveRtt: Boolean = false,
+        val rttMs: Int = 0,
+        val lossPct: Int = 0,
+        val quality: Int = LINK_QUALITY_UNKNOWN,
+    )
+
+    private external fun nativeLinkHealth(): IntArray
+
+    fun linkHealth(): LinkHealth {
+        val raw = nativeLinkHealth()
+        if (raw.size < 4) return LinkHealth()
+        return LinkHealth(raw[0] != 0, raw[1], raw[2], raw[3])
+    }
+
+    private external fun nativeLinkPingText(
+        haveRtt: Boolean,
+        rttMs: Int,
+    ): String
+
+    fun linkPingText(health: LinkHealth): String = nativeLinkPingText(health.haveRtt, health.rttMs)
 
     suspend fun listSources(
         addr: String,

--- a/client/android/app/src/main/java/com/deskhub/app/StreamActivity.kt
+++ b/client/android/app/src/main/java/com/deskhub/app/StreamActivity.kt
@@ -82,6 +82,8 @@ import androidx.compose.ui.viewinterop.AndroidView
 import kotlinx.coroutines.delay
 import kotlin.math.roundToInt
 
+private const val LINK_POLL_MS = 1000L
+
 class StreamActivity : ComponentActivity() {
     private var session by mutableStateOf(0L)
 
@@ -256,6 +258,22 @@ private fun StreamScreen(
     }
 
     val streaming = sessionPhase == NativeClient.PHASE_STREAMING
+    val reattaching = sessionPhase == NativeClient.PHASE_REATTACHING
+
+    var linkHealth by remember { mutableStateOf(NativeClient.LinkHealth()) }
+    LaunchedEffect(sessionKey) {
+        if (!started) return@LaunchedEffect
+        while (sessionPhase != NativeClient.PHASE_ENDED) {
+            linkHealth = NativeClient.linkHealth()
+            NativeClient.nativeSnapshot()?.let { snap ->
+                sessionPhase = snap.phase
+                if (snap.phase == NativeClient.PHASE_ENDED && endReason.isEmpty()) {
+                    endReason = snap.endReason
+                }
+            }
+            delay(LINK_POLL_MS)
+        }
+    }
 
     trustAsk?.let { (verdict, fingerprint) ->
         val changed = verdict == NativeClient.TRUST_CHANGED
@@ -483,6 +501,8 @@ private fun StreamScreen(
                     reason = if (!started) NativeClient.couldNotConnect(address) else endReason,
                     onBack = onDismiss,
                 )
+            } else if (reattaching) {
+                ReattachingBanner()
             } else if (!streaming) {
                 ConnectingOverlay(address = address)
             }
@@ -514,6 +534,7 @@ private fun StreamScreen(
                     videoW = videoW,
                     videoH = videoH,
                     statusLine = statusLine,
+                    linkHealth = linkHealth,
                     streaming = streaming,
                     keyboardOn = keyboardOn,
                     sources = sources,
@@ -641,12 +662,23 @@ private fun ExpandButton(onClick: () -> Unit) {
     }
 }
 
+private fun linkQualityLabel(quality: Int): String =
+    NativeClient.string(
+        when (quality) {
+            NativeClient.LINK_QUALITY_GOOD -> NativeClient.STR_LINK_QUALITY_GOOD
+            NativeClient.LINK_QUALITY_FAIR -> NativeClient.STR_LINK_QUALITY_FAIR
+            NativeClient.LINK_QUALITY_POOR -> NativeClient.STR_LINK_QUALITY_POOR
+            else -> NativeClient.STR_LINK_NO_READING
+        },
+    )
+
 @Composable
 private fun ControlPanel(
     address: String,
     videoW: Int,
     videoH: Int,
     statusLine: String,
+    linkHealth: NativeClient.LinkHealth,
     streaming: Boolean,
     keyboardOn: Boolean,
     sources: List<NativeClient.Source>,
@@ -694,6 +726,16 @@ private fun ControlPanel(
                         maxLines = 1,
                     )
                 }
+                if (streaming) {
+                    Text(
+                        text =
+                            linkQualityLabel(linkHealth.quality) + " · " +
+                                NativeClient.linkPingText(linkHealth),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = Color.White.copy(alpha = 0.8f),
+                        maxLines = 1,
+                    )
+                }
             }
             Box(
                 modifier =
@@ -735,8 +777,28 @@ private fun ControlPanel(
                 OutlinedButton(onClick = { pickerOpen = true }) { Text("Display") }
             }
             Box(modifier = Modifier.weight(1f))
-            Button(onClick = onEnd) { Text("End") }
+            Button(onClick = onEnd) {
+                Text(NativeClient.string(NativeClient.STR_DISCONNECT_BUTTON))
+            }
         }
+    }
+}
+
+@Composable
+private fun ReattachingBanner() {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.TopCenter,
+    ) {
+        Text(
+            NativeClient.string(NativeClient.STR_LINK_REATTACHING),
+            color = Color.White,
+            modifier =
+                Modifier
+                    .padding(12.dp)
+                    .background(Color.Black.copy(alpha = 0.75f))
+                    .padding(horizontal = 12.dp, vertical = 6.dp),
+        )
     }
 }
 

--- a/client/apple/swift/ClientTypes.swift
+++ b/client/apple/swift/ClientTypes.swift
@@ -5,6 +5,8 @@ nonisolated enum Phase: Int, Sendable {
     case connecting = 1
     case streaming = 2
     case ended = 3
+    case deciding = 4
+    case reattaching = 5
 }
 
 nonisolated enum MouseButton: Int32, Sendable {

--- a/client/apple/swift/ConnectionStatusBar.swift
+++ b/client/apple/swift/ConnectionStatusBar.swift
@@ -1,0 +1,58 @@
+import SwiftUI
+
+enum LinkHealthStyle {
+    static func dotColor(_ quality: DHLinkQuality) -> Color {
+        switch quality {
+        case DHLinkQualityGood: .green
+        case DHLinkQualityFair: .orange
+        case DHLinkQualityPoor: .red
+        default: .gray
+        }
+    }
+}
+
+struct LinkHealthRow: View {
+    let health: DHLinkHealth
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Circle()
+                .fill(LinkHealthStyle.dotColor(health.quality))
+                .frame(width: 8, height: 8)
+            Text(DeskhubClient.linkQualityText(health.quality))
+            Text(DeskhubClient.linkPingText(haveRtt: health.haveRtt, rttMs: health.rttMs))
+                .foregroundStyle(.secondary)
+        }
+    }
+}
+
+struct ConnectionStatusBar: View {
+    let model: StreamModel
+    let onDisconnect: () -> Void
+
+    var body: some View {
+        HStack(spacing: 10) {
+            leading
+            Spacer(minLength: 12)
+            Text(model.address)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+            Button(DeskhubClient.string(DHStrDisconnectButton), action: onDisconnect)
+        }
+        .font(.callout)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
+        .background(.bar)
+    }
+
+    @ViewBuilder private var leading: some View {
+        if model.reattaching {
+            ProgressView()
+                .controlSize(.small)
+            Text(DeskhubClient.string(DHStrLinkReattaching))
+        } else {
+            LinkHealthRow(health: model.linkHealth)
+        }
+    }
+}

--- a/client/apple/swift/DeskhubClient.swift
+++ b/client/apple/swift/DeskhubClient.swift
@@ -29,6 +29,14 @@ nonisolated enum DeskhubClient {
         dh_is_zoomed(zoom)
     }
 
+    static func linkQualityText(_ quality: DHLinkQuality) -> String {
+        buffered(64) { dh_link_quality_text(quality, $0, $1) }
+    }
+
+    static func linkPingText(haveRtt: Bool, rttMs: UInt32) -> String {
+        buffered(32) { dh_link_ping_text(haveRtt, rttMs, $0, $1) }
+    }
+
     static func buffered(
         _ capacity: Int, _ fill: (UnsafeMutablePointer<CChar>, Int32) -> Int32
     ) -> String {

--- a/client/apple/swift/ScreenSession.swift
+++ b/client/apple/swift/ScreenSession.swift
@@ -125,6 +125,12 @@ final class ScreenSession: @unchecked Sendable {
         Phase(rawValue: Int(dh_screen_phase(handle).rawValue)) ?? .idle
     }
 
+    func linkHealth() -> DHLinkHealth {
+        var raw = DHLinkHealth()
+        dh_screen_link_health(handle, &raw)
+        return raw
+    }
+
     func offerClipboard(_ text: String) {
         guard !text.isEmpty else { return }
         dh_screen_clip_offer(handle, text)

--- a/client/apple/swift/StreamModel.swift
+++ b/client/apple/swift/StreamModel.swift
@@ -13,6 +13,7 @@ final class StreamModel {
     var phase: Phase = .connecting
     var statusLine = ""
     var endReason = ""
+    var linkHealth = DHLinkHealth()
     var videoWidth: UInt32 = 0
     var videoHeight: UInt32 = 0
     var failedToStart = false
@@ -25,6 +26,9 @@ final class StreamModel {
 
     private var session: ScreenSession?
     private var layer: AVSampleBufferDisplayLayer?
+    private var healthTimer: Timer?
+
+    var reattaching: Bool { phase == .reattaching }
 
     init(address: String, passcode: String, sourceId: UInt8, sourceName: String,
          control: Bool = true)
@@ -54,10 +58,12 @@ final class StreamModel {
         session = opened
         opened.setLayer(layer)
         refresh()
+        startHealthPolling()
     }
 
     func switchSource(to newSourceId: UInt8, name: String) async {
         guard newSourceId != sourceId else { return }
+        stopHealthPolling()
         session?.stop()
         session = nil
         sourceId = newSourceId
@@ -66,16 +72,19 @@ final class StreamModel {
         statusLine = ""
         videoWidth = 0
         videoHeight = 0
+        linkHealth = DHLinkHealth()
         phase = .connecting
         await start()
     }
 
     func disconnect() {
+        stopHealthPolling()
         mouseLocked = false
         session?.stop()
         session = nil
         phase = .idle
         statusLine = ""
+        linkHealth = DHLinkHealth()
     }
 
     func setLayer(_ newLayer: AVSampleBufferDisplayLayer?) {
@@ -157,6 +166,32 @@ final class StreamModel {
         }
     }
 
+    private func startHealthPolling() {
+        healthTimer?.invalidate()
+        healthTimer = Timer.scheduledTimer(
+            withTimeInterval: 1, repeats: true
+        ) { [weak self] _ in
+            Task { @MainActor in self?.pollHealth() }
+        }
+    }
+
+    private func stopHealthPolling() {
+        healthTimer?.invalidate()
+        healthTimer = nil
+    }
+
+    private func pollHealth() {
+        guard let session, phase != .ended else {
+            stopHealthPolling()
+            return
+        }
+        let livePhase = session.phase()
+        if livePhase != .ended, livePhase != phase {
+            phase = livePhase
+        }
+        linkHealth = session.linkHealth()
+    }
+
     private func makeHandlers() -> ScreenSessionHandlers {
         ScreenSessionHandlers(
             onStatus: { [weak self] line in
@@ -177,6 +212,7 @@ final class StreamModel {
             onClosed: { [weak self] reason in
                 Task { @MainActor in
                     guard let self else { return }
+                    self.stopHealthPolling()
                     self.phase = .ended
                     self.endReason = reason
                     self.mouseLocked = false

--- a/client/ios/app/swift/StreamOverlays.swift
+++ b/client/ios/app/swift/StreamOverlays.swift
@@ -8,6 +8,8 @@ struct StatusOverlay: View {
     var body: some View {
         if model.phase == .ended {
             ended
+        } else if model.reattaching {
+            reattaching
         } else if !streaming {
             connecting
         }
@@ -19,6 +21,15 @@ struct StatusOverlay: View {
             Text(DeskhubClient.connectingTo(model.address))
                 .foregroundStyle(.white)
         }
+    }
+
+    private var reattaching: some View {
+        VStack(spacing: 12) {
+            ProgressView()
+            Text(DeskhubClient.string(DHStrLinkReattaching))
+                .foregroundStyle(.white)
+        }
+        .allowsHitTesting(false)
     }
 
     private var ended: some View {

--- a/client/ios/app/swift/StreamView.swift
+++ b/client/ios/app/swift/StreamView.swift
@@ -197,6 +197,9 @@ struct StreamView: View {
                         .foregroundStyle(.white)
                         .lineLimit(1)
                         .truncationMode(.middle)
+                    LinkHealthRow(health: model.linkHealth)
+                        .font(.caption)
+                        .foregroundStyle(.white.opacity(0.8))
                     if streaming, !model.statusLine.isEmpty {
                         Text(model.statusLine)
                             .font(.caption)

--- a/client/linux/gtk/ViewerWindow.cpp
+++ b/client/linux/gtk/ViewerWindow.cpp
@@ -27,6 +27,8 @@ constexpr int32_t kWheelDelta = deskhub::kWheelDeltaPerNotch;
 constexpr int kInitialW = 1024;
 constexpr int kInitialH = 600;
 
+constexpr const char* kStatusSeparator = " \xC2\xB7 ";
+
 GdkRectangle WorkArea(GtkWidget* w) {
     GdkRectangle wa{0, 0, kInitialW, kInitialH};
     GdkDisplay* d = gtk_widget_get_display(w);
@@ -96,6 +98,11 @@ bool ViewerWindow::Build(const NetAddr& server, uint8_t sourceId, const std::str
 
     GtkWidget* header = gtk_header_bar_new();
     gtk_header_bar_set_show_close_button(GTK_HEADER_BAR(header), TRUE);
+    GtkWidget* disconnectButton = gtk_button_new_with_label(deskhub::ui::kDisconnectButton);
+    g_signal_connect(disconnectButton, "clicked", G_CALLBACK(OnDisconnectClicked), this);
+    gtk_header_bar_pack_end(GTK_HEADER_BAR(header), disconnectButton);
+    linkLabel_ = gtk_label_new(deskhub::ui::kLinkNoReading);
+    gtk_header_bar_pack_end(GTK_HEADER_BAR(header), linkLabel_);
     gtk_window_set_titlebar(GTK_WINDOW(window_), header);
 
     glArea_ = gtk_gl_area_new();
@@ -167,6 +174,7 @@ bool ViewerWindow::Build(const NetAddr& server, uint8_t sourceId, const std::str
 
     clipboardSync_ = deskhubp::LoadUiSettings().clipboardSync;
     if (clipboardSync_) clipTimerId_ = g_timeout_add(1000, OnClipboardTimer, this);
+    linkTimerId_ = g_timeout_add(1000, OnLinkTimer, this);
 
     UpdateTitle();
     gtk_widget_show_all(window_);
@@ -285,6 +293,26 @@ void ViewerWindow::UpdateTitle() {
     if (title == shownTitle_) return;
     shownTitle_ = std::move(title);
     gtk_window_set_title(GTK_WINDOW(window_), shownTitle_.c_str());
+}
+
+void ViewerWindow::UpdateLinkLabel() {
+    if (!linkLabel_) return;
+    std::string text;
+    if (loop_.phase() == deskhubp::ClientPhase::Reattaching) {
+        text = deskhub::ui::kTerminalReattaching;
+    } else {
+        const deskhub::LinkPulseView health = loop_.LinkHealth();
+        text = deskhub::ui::LinkQualityText(health.quality);
+        text += kStatusSeparator;
+        text += deskhub::ui::LinkPingText(health.haveRtt, health.rttUs);
+    }
+    gtk_label_set_text(GTK_LABEL(linkLabel_), text.c_str());
+}
+
+gboolean ViewerWindow::OnLinkTimer(gpointer user) {
+    auto* self = static_cast<ViewerWindow*>(user);
+    self->UpdateLinkLabel();
+    return G_SOURCE_CONTINUE;
 }
 
 void ViewerWindow::SizeToVideo() {
@@ -435,12 +463,21 @@ gboolean ViewerWindow::OnFocusOut(GtkWidget*, GdkEventFocus*, gpointer user) {
     return FALSE;
 }
 
+void ViewerWindow::OnDisconnectClicked(GtkWidget*, gpointer user) {
+    auto* self = static_cast<ViewerWindow*>(user);
+    gtk_window_close(GTK_WINDOW(self->window_));
+}
+
 void ViewerWindow::OnDestroy(GtkWidget*, gpointer user) {
     auto* self = static_cast<ViewerWindow*>(user);
     self->tickId_ = 0;
     if (self->clipTimerId_) {
         g_source_remove(self->clipTimerId_);
         self->clipTimerId_ = 0;
+    }
+    if (self->linkTimerId_) {
+        g_source_remove(self->linkTimerId_);
+        self->linkTimerId_ = 0;
     }
     self->window_ = nullptr;
     auto done = std::move(self->onClosed_);

--- a/client/linux/gtk/ViewerWindow.h
+++ b/client/linux/gtk/ViewerWindow.h
@@ -35,6 +35,7 @@ private:
     void GrabPointer(bool locked);
     void AskAboutKey(deskhub::TrustVerdict verdict, const std::string& fingerprint);
     void UpdateTitle();
+    void UpdateLinkLabel();
     void SizeToVideo();
     void EndSession();
 
@@ -50,15 +51,19 @@ private:
     static gboolean OnFocusOut(GtkWidget* w, GdkEventFocus* e, gpointer user);
     static gboolean OnTick(GtkWidget* w, GdkFrameClock* clock, gpointer user);
     static void OnDestroy(GtkWidget* w, gpointer user);
+    static void OnDisconnectClicked(GtkWidget* w, gpointer user);
 
     GtkWidget* window_ = nullptr;
     GtkWidget* glArea_ = nullptr;
+    GtkWidget* linkLabel_ = nullptr;
     guint tickId_ = 0;
     uint64_t queuedFrameSerial_ = 0;
     guint clipTimerId_ = 0;
+    guint linkTimerId_ = 0;
     bool clipboardSync_ = false;
 
     static gboolean OnClipboardTimer(gpointer user);
+    static gboolean OnLinkTimer(gpointer user);
 
     std::shared_ptr<ViewerWindow*> alive_;
 

--- a/client/macos/app/swift/StreamView.swift
+++ b/client/macos/app/swift/StreamView.swift
@@ -99,16 +99,19 @@ struct StreamView: View {
     let onEnd: () -> Void
 
     var body: some View {
-        RemoteView(
-            model: model,
-            videoSize: videoSize,
-            mouseLocked: model.mouseLocked,
-            onLayerReady: { layer in model.setLayer(layer) },
-            onLockChanged: { model.mouseLocked = $0 }
-        )
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(Color.black)
-        .environment(\.colorScheme, .dark)
+        VStack(spacing: 0) {
+            ConnectionStatusBar(model: model, onDisconnect: onEnd)
+            RemoteView(
+                model: model,
+                videoSize: videoSize,
+                mouseLocked: model.mouseLocked,
+                onLayerReady: { layer in model.setLayer(layer) },
+                onLockChanged: { model.mouseLocked = $0 }
+            )
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(Color.black)
+            .environment(\.colorScheme, .dark)
+        }
         .trustPrompt(
             isPresented: $model.askingTrust,
             changed: model.trustChanged,

--- a/client/windows/win32/Viewer.cpp
+++ b/client/windows/win32/Viewer.cpp
@@ -36,6 +36,8 @@ constexpr UINT WM_APP_TRUST = WM_APP + 4;
 constexpr UINT kTimerHint = 1;
 constexpr UINT kTimerClipboard = 2;
 
+constexpr const char* kStatusSeparator = " \xC2\xB7 ";
+
 std::string ReadClipboardText(HWND owner) {
     if (!OpenClipboard(owner)) return {};
     std::string out;
@@ -103,12 +105,28 @@ struct ViewerFrame {
             std::max(1, int(r.height)), TRUE);
     }
 
+    void AppendLinkHealth(std::string& line) {
+        if (!session) return;
+        if (dh_screen_phase(session) != DHPhaseStreaming) return;
+        DHLinkHealth health{};
+        dh_screen_link_health(session, &health);
+        char qualityText[32];
+        dh_link_quality_text(health.quality, qualityText, sizeof(qualityText));
+        char pingText[32];
+        dh_link_ping_text(health.haveRtt, health.rttMs, pingText, sizeof(pingText));
+        if (!line.empty()) line += kStatusSeparator;
+        line += qualityText;
+        line += kStatusSeparator;
+        line += pingText;
+    }
+
     void UpdateTitle() {
         std::string line;
         {
             std::lock_guard<std::mutex> lk(mu);
             line = statsLine;
         }
+        AppendLinkHealth(line);
         const std::string title =
             viewOnly
                 ? deskhub::ComposeViewerTitle(baseTitle, line, deskhub::kViewerViewOnlyHint)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -36,6 +36,7 @@ add_library(core STATIC
     src/transfer/Crc32.cpp
     src/transfer/SafeName.cpp
     src/session/LinkRecovery.cpp
+    src/session/LinkPulse.cpp
 
     src/input/InputSender.cpp
     src/input/InputReceiver.cpp
@@ -130,6 +131,7 @@ if(DESKHUB_CORE_TESTS)
         tests/session/TerminalSessionTests.cpp
         tests/session/FileTransferTests.cpp
         tests/session/LinkRecoveryTests.cpp
+        tests/session/LinkPulseTests.cpp
         tests/session/AuthThrottleTests.cpp
 
         tests/transfer/Crc32Tests.cpp

--- a/core/include/deskhub/session/LinkPulse.h
+++ b/core/include/deskhub/session/LinkPulse.h
@@ -1,0 +1,56 @@
+#pragma once
+#include "deskhub/protocol/Wire.h"
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+
+namespace deskhub {
+
+inline constexpr uint64_t kLinkPingIntervalUs = 1'000'000;
+inline constexpr uint64_t kLinkPingLostAfterUs = 2'000'000;
+inline constexpr uint64_t kLinkStallAfterUs = 5'000'000;
+inline constexpr size_t kLinkPingWindow = 10;
+inline constexpr uint32_t kLinkGoodMaxRttUs = 80'000;
+inline constexpr uint32_t kLinkFairMaxRttUs = 200'000;
+inline constexpr uint8_t kLinkFairMaxLossPct = 20;
+
+enum class LinkQuality : uint8_t { Unknown = 0,
+    Good = 1,
+    Fair = 2,
+    Poor = 3 };
+
+struct LinkPulseView {
+    bool haveRtt = false;
+    uint32_t rttUs = 0;
+    uint8_t lossPct = 0;
+    LinkQuality quality = LinkQuality::Unknown;
+};
+
+LinkQuality ClassifyLinkQuality(bool haveRtt, uint32_t rttUs, uint8_t lossPct);
+
+class LinkPulse {
+public:
+    void Reset();
+    bool PingDue(uint64_t nowUs) const;
+    PingPong MakePing(uint64_t nowUs);
+    bool OnPong(const PingPong& pong, uint64_t nowUs);
+    bool Stalled(uint64_t nowUs) const;
+    LinkPulseView View(uint64_t nowUs) const;
+
+private:
+    struct SentPing {
+        uint32_t pingId = 0;
+        uint64_t sentUs = 0;
+        bool answered = false;
+    };
+
+    std::array<SentPing, kLinkPingWindow> sent_{};
+    uint32_t nextPingId_ = 1;
+    uint64_t lastPingUs_ = 0;
+    uint64_t lastPongUs_ = 0;
+    uint64_t smoothedRttUs_ = 0;
+    bool haveRtt_ = false;
+};
+
+}

--- a/core/include/deskhub/session/LinkRecovery.h
+++ b/core/include/deskhub/session/LinkRecovery.h
@@ -11,6 +11,7 @@ bool KeepaliveDue(uint64_t nowUs, uint64_t lastSentUs, uint64_t intervalUs);
 
 inline constexpr uint64_t kReconnectFirstDelayUs = 500'000;
 inline constexpr uint64_t kReconnectMaxDelayUs = 5'000'000;
+inline constexpr uint64_t kViewerReattachGraceUs = 60'000'000;
 
 uint64_t ReconnectDelayUs(uint32_t attempt);
 bool ReconnectStillWorthTrying(uint64_t sinceLossUs, uint64_t graceUs);

--- a/core/include/deskhub/session/client/ScreenClient.h
+++ b/core/include/deskhub/session/client/ScreenClient.h
@@ -37,7 +37,7 @@ struct ScreenClientCallbacks {
     std::function<void(const AudioPacketView&)> onAudioPacket;
     std::function<void(std::string_view text)> onClipboardText;
     std::function<void(const NegotiatedParams&, bool reconfigured)> onParams;
-    std::function<void(const char* reason)> onEnded;
+    std::function<void(const char* reason, ScreenSessionEnd cause)> onEnded;
     std::function<uint32_t()> takeRenderedCount;
     std::function<int64_t()> latencyUs;
     std::function<void(const char* compactStatus)> onStatus;

--- a/core/include/deskhub/session/client/ScreenClientSession.h
+++ b/core/include/deskhub/session/client/ScreenClientSession.h
@@ -26,12 +26,17 @@ struct NegotiatedParams {
     uint64_t timebaseUs = 0;
 };
 
+enum class ScreenSessionEnd : uint8_t { HostBye = 0,
+    Timeout = 1,
+    Rejected = 2,
+    ConnectTimeout = 3 };
+
 struct ScreenClientSessionCallbacks {
     std::function<void(std::span<const uint8_t>)> send;
     std::function<void(const NegotiatedParams&)> onReady;
     std::function<void(const NegotiatedParams&)> onReconfig;
     std::function<void(uint32_t rttUs)> onRtt;
-    std::function<void(const char* reason)> onDisconnect;
+    std::function<void(const char* reason, ScreenSessionEnd cause)> onDisconnect;
     std::function<void(std::string_view text)> onClipboardText;
 };
 
@@ -94,7 +99,7 @@ public:
 private:
     void SendHello();
     void SendStart();
-    void Die(const char* reason);
+    void Die(const char* reason, ScreenSessionEnd cause);
 
     ScreenClientSessionCallbacks cb_;
     InputSender input_;

--- a/core/include/deskhub/ui/Strings.h
+++ b/core/include/deskhub/ui/Strings.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "deskhub/protocol/Wire.h"
+#include "deskhub/session/LinkPulse.h"
 
 #include <cstddef>
 #include <cstdint>
@@ -38,6 +39,21 @@ inline constexpr const char* kViewerOpenFailed =
 inline constexpr const char* kConnectionEndedTitle = "Connection ended";
 inline constexpr const char* kDisconnected = "disconnected";
 inline constexpr const char* kSessionEnded = "Session ended";
+inline constexpr const char* kDisconnectButton = "Disconnect";
+inline constexpr const char* kLinkQualityGood = "Good";
+inline constexpr const char* kLinkQualityFair = "Fair";
+inline constexpr const char* kLinkQualityPoor = "Poor";
+inline constexpr const char* kLinkNoReading = "\xE2\x80\x94";
+
+inline const char* LinkQualityText(LinkQuality quality) {
+    switch (quality) {
+        case LinkQuality::Good: return kLinkQualityGood;
+        case LinkQuality::Fair: return kLinkQualityFair;
+        case LinkQuality::Poor: return kLinkQualityPoor;
+        case LinkQuality::Unknown: break;
+    }
+    return kLinkNoReading;
+}
 inline constexpr const char* kScreenRecordingRequired =
     "Screen Recording permission is required. Grant it in System Settings, then quit and "
     "reopen Deskhub.";
@@ -462,6 +478,11 @@ inline std::string PortCell(uint16_t port) {
 
 inline std::string PingMs(uint32_t ms) {
     return std::to_string(ms) + " ms";
+}
+
+inline std::string LinkPingText(bool haveRtt, uint32_t rttUs) {
+    if (!haveRtt) return kLinkNoReading;
+    return PingMs((rttUs + 500) / 1000);
 }
 
 inline std::string SharingStatusLine(uint16_t port) {

--- a/core/src/session/LinkPulse.cpp
+++ b/core/src/session/LinkPulse.cpp
@@ -1,0 +1,66 @@
+#include "deskhub/session/LinkPulse.h"
+
+namespace deskhub {
+
+LinkQuality ClassifyLinkQuality(bool haveRtt, uint32_t rttUs, uint8_t lossPct) {
+    if (!haveRtt) return LinkQuality::Unknown;
+    if (rttUs >= kLinkFairMaxRttUs || lossPct > kLinkFairMaxLossPct) return LinkQuality::Poor;
+    if (rttUs < kLinkGoodMaxRttUs && lossPct == 0) return LinkQuality::Good;
+    return LinkQuality::Fair;
+}
+
+void LinkPulse::Reset() {
+    *this = LinkPulse{};
+}
+
+bool LinkPulse::PingDue(uint64_t nowUs) const {
+    return lastPingUs_ == 0 || nowUs - lastPingUs_ >= kLinkPingIntervalUs;
+}
+
+PingPong LinkPulse::MakePing(uint64_t nowUs) {
+    const PingPong ping{nextPingId_++, nowUs};
+    sent_[ping.pingId % kLinkPingWindow] = SentPing{ping.pingId, nowUs, false};
+    lastPingUs_ = nowUs;
+    return ping;
+}
+
+bool LinkPulse::OnPong(const PingPong& pong, uint64_t nowUs) {
+    SentPing& slot = sent_[pong.pingId % kLinkPingWindow];
+    if (slot.pingId != pong.pingId || slot.answered) return false;
+    if (slot.sentUs != pong.sendTimeUs || nowUs < slot.sentUs) return false;
+    slot.answered = true;
+    lastPongUs_ = nowUs;
+    const uint64_t sample = nowUs - slot.sentUs;
+    smoothedRttUs_ = haveRtt_ ? (smoothedRttUs_ * 7 + sample) / 8 : sample;
+    haveRtt_ = true;
+    return true;
+}
+
+bool LinkPulse::Stalled(uint64_t nowUs) const {
+    return haveRtt_ && nowUs - lastPongUs_ > kLinkStallAfterUs;
+}
+
+LinkPulseView LinkPulse::View(uint64_t nowUs) const {
+    uint32_t decided = 0;
+    uint32_t lost = 0;
+    for (const SentPing& ping : sent_) {
+        if (ping.pingId == 0) continue;
+        if (ping.answered) {
+            ++decided;
+            continue;
+        }
+        if (nowUs - ping.sentUs < kLinkPingLostAfterUs) continue;
+        ++decided;
+        ++lost;
+    }
+
+    LinkPulseView view;
+    view.haveRtt = haveRtt_;
+    view.rttUs = uint32_t(smoothedRttUs_);
+    view.lossPct = decided ? uint8_t(lost * 100 / decided) : uint8_t(0);
+    view.quality = Stalled(nowUs) ? LinkQuality::Poor
+                                  : ClassifyLinkQuality(haveRtt_, view.rttUs, view.lossPct);
+    return view;
+}
+
+}

--- a/core/src/session/client/ScreenClient.cpp
+++ b/core/src/session/client/ScreenClient.cpp
@@ -37,11 +37,11 @@ ScreenClientSessionCallbacks ScreenClient::MakeSessionCallbacks() {
     sc.onClipboardText = [this](std::string_view text) {
         if (cb_.onClipboardText) cb_.onClipboardText(text);
     };
-    sc.onDisconnect = [this](const char* reason) {
+    sc.onDisconnect = [this](const char* reason, ScreenSessionEnd cause) {
         std::snprintf(line_, sizeof(line_), "[Client] Disconnected: %s",
             reason ? reason : "disconnected");
         Log(line_);
-        if (cb_.onEnded) cb_.onEnded(reason ? reason : "disconnected");
+        if (cb_.onEnded) cb_.onEnded(reason ? reason : "disconnected", cause);
     };
     return sc;
 }
@@ -50,6 +50,7 @@ void ScreenClient::Start(const ScreenClientConfig& cfg, uint64_t nowUs) {
     cfg_ = cfg;
     linkStats_ = LinkStats(nowUs);
     windowBytes_ = 0;
+    reasm_.reset();
 
     Hello hello;
     hello.clientId = cfg.clientId;

--- a/core/src/session/client/ScreenClientSession.cpp
+++ b/core/src/session/client/ScreenClientSession.cpp
@@ -27,16 +27,18 @@ bool ScreenClientSession::HandlePacket(std::span<const uint8_t> pkt, uint64_t no
                 rejectReason_ = m->reason;
                 switch (m->reason) {
                     case RejectReason::CodecMismatch:
-                        Die("host rejected (codec mismatch)");
+                        Die("host rejected (codec mismatch)", ScreenSessionEnd::Rejected);
                         return false;
                     case RejectReason::Busy:
-                        Die("the host already has as many viewers as it can take");
+                        Die("the host already has as many viewers as it can take",
+                            ScreenSessionEnd::Rejected);
                         return false;
                     case RejectReason::WrongPasscode:
-                        Die("wrong passcode — check the 4-digit code on the host");
+                        Die("wrong passcode — check the 4-digit code on the host",
+                            ScreenSessionEnd::Rejected);
                         return false;
                     default:
-                        Die("host rejected (busy or codec mismatch)");
+                        Die("host rejected (busy or codec mismatch)", ScreenSessionEnd::Rejected);
                         return false;
                 }
             }
@@ -81,7 +83,7 @@ bool ScreenClientSession::HandlePacket(std::span<const uint8_t> pkt, uint64_t no
         }
         case MsgType::Bye:
             if (h->sessionId != sessionId_ || sessionId_ == 0) return false;
-            Die("host ended the session (BYE)");
+            Die("host ended the session (BYE)", ScreenSessionEnd::HostBye);
             return false;
         case MsgType::Clipboard: {
             if (h->sessionId != sessionId_ || sessionId_ == 0) return false;
@@ -131,7 +133,7 @@ void ScreenClientSession::Tick(uint64_t nowUs) {
             return;
         case State::Hello:
             if (nowUs - startedUs_ > kHelloGiveUpUs) {
-                Die("could not connect (timed out)");
+                Die("could not connect (timed out)", ScreenSessionEnd::ConnectTimeout);
                 return;
             }
             if (nowUs - lastSentUs_ >= kHelloRetryUs) {
@@ -150,7 +152,7 @@ void ScreenClientSession::Tick(uint64_t nowUs) {
     }
 
     if (nowUs - lastRecvUs_ > kSessionTimeoutUs) {
-        Die("lost contact with host (timeout)");
+        Die("lost contact with host (timeout)", ScreenSessionEnd::Timeout);
         return;
     }
 
@@ -219,9 +221,9 @@ void ScreenClientSession::SendStart() {
     if (n && cb_.send) cb_.send(std::span<const uint8_t>(buf_, n));
 }
 
-void ScreenClientSession::Die(const char* reason) {
+void ScreenClientSession::Die(const char* reason, ScreenSessionEnd cause) {
     state_ = State::Dead;
-    if (cb_.onDisconnect) cb_.onDisconnect(reason);
+    if (cb_.onDisconnect) cb_.onDisconnect(reason, cause);
 }
 
 }

--- a/core/tests/TestMain.cpp
+++ b/core/tests/TestMain.cpp
@@ -70,6 +70,9 @@ int main() {
     std::printf("--- session: keeping a link alive and getting it back ---\n");
     RunLinkRecoveryTests();
 
+    std::printf("--- session: the link's own ping, loss and quality reading ---\n");
+    RunLinkPulseTests();
+
     std::printf("--- session: passcode attempt throttle ---\n");
     RunAuthThrottleTests();
 

--- a/core/tests/Tests.h
+++ b/core/tests/Tests.h
@@ -21,6 +21,7 @@ void RunFileTransferTests();
 void RunCrc32Tests();
 void RunSafeNameTests();
 void RunLinkRecoveryTests();
+void RunLinkPulseTests();
 void RunAuthThrottleTests();
 void RunInputTests();
 void RunPressedInputTests();

--- a/core/tests/session/LinkPulseTests.cpp
+++ b/core/tests/session/LinkPulseTests.cpp
@@ -1,0 +1,145 @@
+#include "Tests.h"
+#include "support/TestSupport.h"
+
+#include "deskhub/session/LinkPulse.h"
+#include "deskhub/ui/Strings.h"
+
+#include <cstdio>
+
+using namespace deskhub;
+
+namespace {
+
+void TestPingsGoOutOncePerSecond() {
+    std::printf("[pulse] pings go out once a second, starting immediately...\n");
+    LinkPulse pulse;
+    Check(pulse.PingDue(5), "the first ping is due the moment the link is up");
+    const PingPong first = pulse.MakePing(5);
+    Check(!pulse.PingDue(5 + kLinkPingIntervalUs - 1), "one microsecond early is still early");
+    Check(pulse.PingDue(5 + kLinkPingIntervalUs), "on the interval the next one is due");
+    const PingPong second = pulse.MakePing(5 + kLinkPingIntervalUs);
+    Check(second.pingId == first.pingId + 1, "every ping carries a fresh id");
+    Check(second.sendTimeUs == 5 + kLinkPingIntervalUs, "and stamps when it left");
+}
+
+void TestRttComesFromTheEchoedPing() {
+    std::printf("[pulse] the pong's echo turns into a smoothed round-trip time...\n");
+    LinkPulse pulse;
+    uint64_t now = 1'000'000;
+    const PingPong first = pulse.MakePing(now);
+    Check(!pulse.View(now).haveRtt, "before any pong there is no reading");
+    Check(pulse.View(now).quality == LinkQuality::Unknown, "so the quality is unknown");
+
+    Check(pulse.OnPong(first, now + 40'000), "the first pong is accepted");
+    LinkPulseView view = pulse.View(now + 40'000);
+    Check(view.haveRtt, "one pong is enough for a reading");
+    Check(view.rttUs == 40'000, "the first sample is taken as-is");
+
+    now += kLinkPingIntervalUs;
+    const PingPong second = pulse.MakePing(now);
+    Check(pulse.OnPong(second, now + 8'000), "the next pong is accepted too");
+    view = pulse.View(now + 8'000);
+    Check(view.rttUs == 36'000, "later samples are smoothed instead of jumping");
+    Check(view.quality == LinkQuality::Good, "a fast, lossless link reads as good");
+}
+
+void TestAPongMustMatchWhatWasSent() {
+    std::printf("[pulse] a pong that does not match a ping we sent is ignored...\n");
+    LinkPulse pulse;
+    const uint64_t now = 2'000'000;
+    const PingPong sent = pulse.MakePing(now);
+
+    Check(!pulse.OnPong(PingPong{sent.pingId + 500, sent.sendTimeUs}, now + 1'000),
+        "an id we never sent is ignored");
+    Check(!pulse.OnPong(PingPong{sent.pingId, sent.sendTimeUs + 1}, now + 1'000),
+        "a doctored timestamp is ignored");
+    Check(!pulse.OnPong(sent, now - 1), "a pong from before the ping left is ignored");
+    Check(pulse.OnPong(sent, now + 1'000), "the genuine pong still lands");
+    Check(!pulse.OnPong(sent, now + 2'000), "and answering twice does not count twice");
+    Check(pulse.View(now + 2'000).rttUs == 1'000, "only the first answer set the reading");
+}
+
+void TestUnansweredPingsCountAsLoss() {
+    std::printf("[pulse] a ping nobody answered becomes loss, but not right away...\n");
+    LinkPulse pulse;
+    uint64_t now = 3'000'000;
+    pulse.MakePing(now);
+    now += kLinkPingIntervalUs;
+    const PingPong answered = pulse.MakePing(now);
+    Check(pulse.OnPong(answered, now + 100'000), "the second ping gets its pong");
+
+    LinkPulseView view = pulse.View(now + 100'000);
+    Check(view.lossPct == 0, "the first ping is still in flight, not lost");
+
+    view = pulse.View(now + kLinkPingLostAfterUs);
+    Check(view.lossPct == 50, "once its window passes, one of two pings counts as lost");
+    Check(view.quality == LinkQuality::Poor, "that much loss reads as poor");
+}
+
+void TestQualityBandsAreStable() {
+    std::printf("[pulse] the quality bands sit where the thresholds say...\n");
+    Check(ClassifyLinkQuality(false, 0, 0) == LinkQuality::Unknown,
+        "no reading means no verdict");
+    Check(ClassifyLinkQuality(true, kLinkGoodMaxRttUs - 1, 0) == LinkQuality::Good,
+        "fast and lossless is good");
+    Check(ClassifyLinkQuality(true, kLinkGoodMaxRttUs, 0) == LinkQuality::Fair,
+        "at the good ceiling it turns fair");
+    Check(ClassifyLinkQuality(true, 10'000, 1) == LinkQuality::Fair,
+        "any loss at all costs the good rating");
+    Check(ClassifyLinkQuality(true, kLinkFairMaxRttUs - 1, kLinkFairMaxLossPct) ==
+              LinkQuality::Fair,
+        "the fair band stretches to its own ceilings");
+    Check(ClassifyLinkQuality(true, kLinkFairMaxRttUs, 0) == LinkQuality::Poor,
+        "past the fair ceiling it is poor however clean");
+    Check(ClassifyLinkQuality(true, 10'000, kLinkFairMaxLossPct + 1) == LinkQuality::Poor,
+        "and heavy loss is poor however fast");
+}
+
+void TestAStalledLinkNeedsAFirstPong() {
+    std::printf("[pulse] silence only reads as a stall once the host has answered before...\n");
+    LinkPulse pulse;
+    uint64_t now = 4'000'000;
+    const PingPong first = pulse.MakePing(now);
+    Check(!pulse.Stalled(now + kLinkStallAfterUs * 3),
+        "a host that never answers pings is never called stalled");
+
+    Check(pulse.OnPong(first, now + 50'000), "then the host answers once");
+    now += 50'000;
+    Check(!pulse.Stalled(now + kLinkStallAfterUs), "silence inside the window is fine");
+    Check(pulse.Stalled(now + kLinkStallAfterUs + 1), "past the window the link has stalled");
+    Check(pulse.View(now + kLinkStallAfterUs + 1).quality == LinkQuality::Poor,
+        "and a stalled link reads as poor");
+
+    pulse.Reset();
+    Check(!pulse.Stalled(now + kLinkStallAfterUs * 2),
+        "a fresh connection starts with a clean slate");
+    Check(pulse.View(now).quality == LinkQuality::Unknown, "and no reading");
+}
+
+void TestTheReadingsTurnIntoWords() {
+    std::printf("[pulse] the readings turn into the words the status bar shows...\n");
+    Check(std::string(ui::LinkQualityText(LinkQuality::Good)) == ui::kLinkQualityGood,
+        "good has its word");
+    Check(std::string(ui::LinkQualityText(LinkQuality::Fair)) == ui::kLinkQualityFair,
+        "fair has its word");
+    Check(std::string(ui::LinkQualityText(LinkQuality::Poor)) == ui::kLinkQualityPoor,
+        "poor has its word");
+    Check(std::string(ui::LinkQualityText(LinkQuality::Unknown)) == ui::kLinkNoReading,
+        "no reading shows a dash, not a guess");
+    Check(ui::LinkPingText(true, 23'400) == "23 ms", "the ping rounds to whole milliseconds");
+    Check(ui::LinkPingText(true, 23'600) == "24 ms", "rounding to nearest, not down");
+    Check(ui::LinkPingText(false, 0) == ui::kLinkNoReading,
+        "and no pong yet shows the same dash");
+}
+
+}
+
+void RunLinkPulseTests() {
+    TestPingsGoOutOncePerSecond();
+    TestRttComesFromTheEchoedPing();
+    TestAPongMustMatchWhatWasSent();
+    TestUnansweredPingsCountAsLoss();
+    TestQualityBandsAreStable();
+    TestAStalledLinkNeedsAFirstPong();
+    TestTheReadingsTurnIntoWords();
+}

--- a/core/tests/session/ScreenClientTests.cpp
+++ b/core/tests/session/ScreenClientTests.cpp
@@ -48,7 +48,7 @@ struct Rig {
             ++paramsCalls;
             if (reconfigured) ++reconfigCalls;
         };
-        cb.onEnded = [this](const char* reason) { ended = reason ? reason : ""; };
+        cb.onEnded = [this](const char* reason, ScreenSessionEnd) { ended = reason ? reason : ""; };
         cb.takeRenderedCount = [this] {
             const uint32_t n = renderedToReport;
             renderedToReport = 0;

--- a/core/tests/session/ScreenSessionTests.cpp
+++ b/core/tests/session/ScreenSessionTests.cpp
@@ -40,7 +40,7 @@ void TestSessions() {
     ccb.send = [&](std::span<const uint8_t> d) { w.toHost.emplace_back(d.begin(), d.end()); };
     ccb.onReady = [&](const NegotiatedParams& p) { cliReady = true; np = p; };
     ccb.onRtt = [&](uint32_t r) { cliRtt = r; };
-    ccb.onDisconnect = [&](const char* r) { cliDead = r; };
+    ccb.onDisconnect = [&](const char* r, ScreenSessionEnd) { cliDead = r; };
     ScreenClientSession cli(ccb);
 
     auto pump = [&] {
@@ -95,7 +95,7 @@ void TestSessions() {
         ScreenClientSessionCallbacks c2 = ccb;
         c2.send = [&](std::span<const uint8_t> d) { w2.toHost.emplace_back(d.begin(), d.end()); };
         c2.onReady = [&](const NegotiatedParams& p) { otherParams = p; };
-        c2.onDisconnect = [&](const char* r) { otherDead = r; };
+        c2.onDisconnect = [&](const char* r, ScreenSessionEnd) { otherDead = r; };
         ScreenClientSession other(c2);
         other.Start(Hello{0x55667788, kCodecMaskH264, 1280, 720, 30, 0, 0, kTestPasscode}, now);
         while (!w2.toHost.empty()) {
@@ -162,7 +162,7 @@ void TestHostKicksOneViewer() {
     std::string cliDead;
     ScreenClientSessionCallbacks ccb;
     ccb.send = [&](std::span<const uint8_t> d) { w.toHost.emplace_back(d.begin(), d.end()); };
-    ccb.onDisconnect = [&](const char* r) { cliDead = r; };
+    ccb.onDisconnect = [&](const char* r, ScreenSessionEnd) { cliDead = r; };
     ScreenClientSession cli(ccb);
 
     auto pump = [&] {
@@ -380,7 +380,7 @@ struct Rig {
         cb.send = [this](std::span<const uint8_t> d) { w.toHost.emplace_back(d.begin(), d.end()); };
         cb.onReady = [this](const NegotiatedParams&) { ++readyCalls; };
         cb.onRtt = [this](uint32_t r) { lastRtt = r; };
-        cb.onDisconnect = [this](const char* r) { cliDead = r; };
+        cb.onDisconnect = [this](const char* r, ScreenSessionEnd) { cliDead = r; };
         cb.onClipboardText = [this](std::string_view t) { cliClipboard.emplace_back(t); };
         return cb;
     }
@@ -550,7 +550,7 @@ void RunHandshakeAgainstBrokenRng(ScreenHostCallbacks hcb, const char* what) {
     std::string cliDead;
     ScreenClientSessionCallbacks ccb;
     ccb.send = [&](std::span<const uint8_t> d) { w.toHost.emplace_back(d.begin(), d.end()); };
-    ccb.onDisconnect = [&](const char* r) { cliDead = r; };
+    ccb.onDisconnect = [&](const char* r, ScreenSessionEnd) { cliDead = r; };
     ScreenClientSession cli(ccb);
 
     cli.Start(Hello{0x3, kCodecMaskH264, 1920, 1080, 60, 0, 0, kTestPasscode}, now);

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -164,16 +164,16 @@ HostEngine (one per app, owns SessionTransport)
 
 Every client surface reaches a host through the same piece, `HostLink`
 (`platform/client/HostLink`): it dials the QUIC connection, checks the trust store,
-runs the auth handshake, keeps the link alive with keepalives, and — for surfaces
-that ask for it — redials with backoff when the link drops. No service dials or
-authenticates on its own any more; a service opens a channel per wire `Chan`, gets
-its own inbox queue, and drains it on its own thread:
+runs the auth handshake, keeps the link alive, and — for surfaces that ask for it —
+redials with backoff when the link drops. No service dials or authenticates on its
+own any more; a service opens a channel per wire `Chan`, gets its own inbox queue,
+and drains it on its own thread:
 
 ```
 HostLink (one per open surface)
  ├─ link thread: dial → trust check → auth → pump
  │   (routes inbound records and datagrams by Chan into per-channel
- │    queues; keepalives; redial with backoff where recovery is on)
+ │    queues; link pulse; redial with backoff where recovery is on)
  ├─ Chan::Control/Video/Audio ─> ScreenViewer
  │    ├─ net thread: HELLO/negotiation, video ingest (Reassembler+FEC),
  │    │   NACKs, feedback, clipboard
@@ -183,6 +183,29 @@ HostLink (one per open surface)
  │    └─ UI polls Snapshot(), posts keys into a command queue
  └─ Chan::File ─> FileTransferClient service thread (FileUpload ring)
 ```
+
+Once admitted, the link takes its own pulse (`core/session/LinkPulse`): a
+`Ping` datagram with session id 0 goes out once a second, the host's beacon answers
+it over the same connection with no session required, and the echoed timestamp
+becomes a smoothed RTT while the ids of pongs that never came back become a loss
+percentage. `ClassifyLinkQuality` folds the two into Good / Fair / Poor for the
+status bars, `HostLink` hands the reading out through `onPulse` and `Pulse()`, and
+because a ping is ack-eliciting it doubles as the keepalive; the plain keepalive
+timer only still matters while the link is parked in `Deciding`. A host too old to
+answer session-0 pings simply leaves the reading at Unknown — nothing regresses.
+On a recovering link the pulse is also the liveness check: five seconds without a
+pong (only ever after a first pong proved the host answers) drops the connection
+into the existing redial path.
+
+The screen viewer now opts into that recovery like the terminal always has: a
+dropped or silent link, or a session that stops receiving for five seconds, parks
+the window in `Reattaching` (the last frame stays up, the status line flips to the
+reattaching text) instead of ending it. `HostLink::RequestRedial` forces the
+redial when the session noticed first, and once the link is readmitted the viewer
+re-runs `HELLO` with the same client id — the host rebinds the viewer slot — and
+streaming resumes off the fresh keyframe. After sixty seconds
+(`kViewerReattachGraceUs`) without getting back in, the window ends with the usual
+reason.
 
 The source query (`QuerySources`) rides the same link in a one-shot, blocking form.
 The UI still posts intents (keys, resize, accept-fingerprint) into command queues;

--- a/docs/ARCHITECTURE.vi.md
+++ b/docs/ARCHITECTURE.vi.md
@@ -163,16 +163,16 @@ HostEngine (một cho cả app, sở hữu SessionTransport)
 
 Mọi bề mặt client đi tới host qua cùng một mảnh, `HostLink`
 (`platform/client/HostLink`): nó quay số kết nối QUIC, kiểm tra kho tin cậy, chạy
-bắt tay auth, giữ kết nối sống bằng keepalive, và — với bề mặt nào yêu cầu — tự quay
-số lại theo backoff khi kết nối rơi. Không dịch vụ nào còn tự quay số hay tự auth;
-mỗi dịch vụ mở một kênh theo `Chan` trên dây, nhận hàng đợi inbox riêng, và tự rút
-trên luồng của chính nó:
+bắt tay auth, giữ kết nối sống, và — với bề mặt nào yêu cầu — tự quay số lại theo
+backoff khi kết nối rơi. Không dịch vụ nào còn tự quay số hay tự auth; mỗi dịch vụ
+mở một kênh theo `Chan` trên dây, nhận hàng đợi inbox riêng, và tự rút trên luồng
+của chính nó:
 
 ```
 HostLink (một cho mỗi bề mặt đang mở)
  ├─ luồng link: quay số → kiểm tra tin cậy → auth → bơm
  │   (chia record và datagram vào hàng đợi theo Chan của từng kênh;
- │    keepalive; quay số lại theo backoff nơi bật khôi phục)
+ │    mạch đập của link; quay số lại theo backoff nơi bật khôi phục)
  ├─ Chan::Control/Video/Audio ─> ScreenViewer
  │    ├─ luồng net: HELLO/thương lượng, nhận video (Reassembler+FEC),
  │    │   NACK, feedback, clipboard
@@ -182,6 +182,27 @@ HostLink (một cho mỗi bề mặt đang mở)
  │    └─ UI poll Snapshot(), post phím vào hàng đợi lệnh
  └─ Chan::File ─> luồng dịch vụ của FileTransferClient (vòng FileUpload)
 ```
+
+Khi đã được nhận vào, link tự bắt mạch cho chính nó (`core/session/LinkPulse`):
+mỗi giây một datagram `Ping` mang session id 0 đi ra, beacon của host trả lời nó
+trên chính kết nối đó mà không cần phiên nào, timestamp được vọng lại trở thành
+RTT đã làm mượt, còn những id không có pong quay về trở thành phần trăm mất gói.
+`ClassifyLinkQuality` gộp hai con số thành Tốt / Khá / Kém cho thanh trạng thái,
+`HostLink` đưa số đo ra qua `onPulse` và `Pulse()`, và vì ping là gói đòi ACK nên
+nó kiêm luôn vai keepalive; bộ đếm keepalive thường chỉ còn có việc khi link đang
+đỗ ở `Deciding`. Host quá cũ không trả lời ping session-0 thì số đo chỉ đứng ở
+Unknown — không gì thoái lui. Trên link có bật khôi phục, mạch đập cũng là phép
+thử sống: năm giây không có pong (và chỉ sau khi pong đầu tiên đã chứng minh host
+có trả lời) là kết nối bị thả xuống đường quay số lại sẵn có.
+
+Viewer màn hình giờ tham gia cơ chế khôi phục đó như terminal xưa nay: link rơi
+hay câm lặng, hoặc phiên năm giây không nhận được gì, sẽ đỗ cửa sổ ở `Reattaching`
+(khung hình cuối vẫn treo, dòng trạng thái chuyển sang chữ đang nối lại) thay vì
+kết thúc nó. `HostLink::RequestRedial` ép quay số lại khi phía phiên nhận ra
+trước, và khi link được nhận vào lại viewer chạy lại `HELLO` với đúng client id
+cũ — host gắn lại slot viewer — rồi hình tiếp tục từ keyframe mới. Sau sáu mươi
+giây (`kViewerReattachGraceUs`) không vào lại được, cửa sổ kết thúc với lý do như
+thường lệ.
 
 Truy vấn nguồn (`QuerySources`) đi cùng loại link đó ở dạng một-lần, chờ-kết-quả.
 UI vẫn đăng ý định (phím, đổi cỡ, chấp nhận dấu vân tay) vào hàng đợi lệnh; key của

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -124,6 +124,8 @@ an alternative face on the behaviour in this document, never a different behavio
 | V-4 | Titled windows | Each viewer window is titled with the source it is showing plus its current status, so multiple sessions are distinguishable. |
 | V-5 | Disconnect | The viewer can end the session at any time. |
 | V-6 | Sound | Where both machines support it (section 3), the viewer hears what the shared machine is playing, in step with the picture to within about a frame. Sound is carried on its own channel: losing a packet costs a fraction of a second of audio and never disturbs the picture, and a machine playing nothing costs almost no bandwidth. It is off for a viewer that turns it off (T-23) and never sent by a host that turns it off (T-22). |
+| V-7 | Connection health | The session window says where it is connected and how the link is doing: a **Good / Fair / Poor** rating and the ping, measured once a second on the session's own connection, next to a **Disconnect** control (V-5). Before the first reply — or against a host too old to answer — the reading is a dash, never a guess. |
+| V-8 | Auto-reconnect | A session that loses its host — the network drops, the stream goes silent — does not end. The window keeps its last picture, states that it is reattaching, and redials with backoff for up to a minute; when the host answers again the picture resumes on its own. Only after that minute, or when the host deliberately ends or refuses the session, does the window close with the reason. A shell window keeps its own two-minute reattach grace as before. |
 
 ## 8. Controlling the remote machine
 

--- a/docs/SPECIFICATION.vi.md
+++ b/docs/SPECIFICATION.vi.md
@@ -128,6 +128,8 @@ mô tả trong tài liệu này, không bao giờ là hành vi khác.
 | V-4 | Cửa sổ có tiêu đề | Mỗi cửa sổ xem có tiêu đề gồm tên nguồn đang xem và trạng thái hiện tại, để phân biệt được khi mở nhiều phiên. |
 | V-5 | Ngắt kết nối | Viewer có thể kết thúc phiên bất cứ lúc nào. |
 | V-6 | Âm thanh | Ở những nơi cả hai máy đều hỗ trợ (mục 3), viewer nghe được thứ máy đang chia sẻ phát ra, lệch hình chừng một khung. Âm thanh đi trên kênh riêng: mất một gói chỉ mất một phần nhỏ của giây tiếng và không bao giờ làm hỏng hình, còn máy không phát gì thì gần như không tốn băng thông. Viewer tắt (T-23) thì không nghe, host tắt (T-22) thì không gửi. |
+| V-7 | Sức khỏe kết nối | Cửa sổ phiên cho biết đang nối tới đâu và đường truyền ra sao: xếp hạng **Tốt / Khá / Kém** cùng ping, đo mỗi giây một lần trên chính kết nối của phiên, đặt cạnh nút **Ngắt kết nối** (V-5). Trước khi có hồi âm đầu tiên — hay gặp host quá cũ không trả lời — số đo là một dấu gạch, không bao giờ là phỏng đoán. |
+| V-8 | Tự nối lại | Phiên mất host — mạng rơi, luồng hình câm lặng — không kết thúc. Cửa sổ giữ khung hình cuối, báo đang nối lại, và quay số lại theo backoff trong tối đa một phút; host trả lời lại là hình tự chạy tiếp. Chỉ sau một phút đó, hoặc khi host chủ động kết thúc hay từ chối phiên, cửa sổ mới đóng kèm lý do. Cửa sổ shell giữ nguyên hai phút ân hạn nối lại như trước. |
 
 ## 8. Điều khiển máy từ xa
 

--- a/platform/include/deskhubp/client/HostLink.h
+++ b/platform/include/deskhubp/client/HostLink.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "deskhub/net/TrustStore.h"
 #include "deskhub/protocol/Wire.h"
+#include "deskhub/session/LinkPulse.h"
 #include "deskhubp/net/SessionTransport.h"
 
 #include <array>
@@ -51,6 +52,7 @@ struct HostLinkCallbacks {
     std::function<void(bool resumed)> onReady;
     std::function<void()> onLinkLost;
     std::function<void(uint64_t streamId)> onStreamBroken;
+    std::function<void(const deskhub::LinkPulseView&)> onPulse;
 };
 
 class HostLinkChannel {
@@ -82,6 +84,9 @@ public:
 
     void AcceptFingerprint();
     void RejectFingerprint();
+
+    void RequestRedial();
+    deskhub::LinkPulseView Pulse() const;
 
     bool Send(std::span<const uint8_t> message);
     bool SendRecordOn(uint64_t streamId, std::span<const uint8_t> message);
@@ -118,6 +123,8 @@ private:
     void SetState(HostLinkState state, std::string_view message);
     void Fail(HostLinkState state, std::string_view message);
     void NoteSent();
+    void SendLinkPing(uint64_t nowUs);
+    void PublishPulse(uint64_t nowUs);
 
     HostLinkConfig config_{};
     HostLinkCallbacks cb_{};
@@ -138,10 +145,13 @@ private:
     std::atomic<bool> stop_{false};
     std::atomic<bool> peerGone_{false};
     std::atomic<bool> autoTrustPending_{false};
+    std::atomic<bool> redial_{false};
     std::atomic<uint64_t> lastSendUs_{0};
     uint64_t keepaliveIntervalUs_ = 0;
     uint64_t linkLostAtUs_ = 0;
     uint32_t redialAttempts_ = 0;
+    deskhub::LinkPulse pulse_{};
+    deskhub::LinkPulseView pulseView_{};
 };
 
 }

--- a/platform/include/deskhubp/client/ScreenViewer.h
+++ b/platform/include/deskhubp/client/ScreenViewer.h
@@ -4,6 +4,7 @@
 #include "deskhub/input/ClientInputQueue.h"
 #include "deskhub/media/VideoContract.h"
 #include "deskhub/protocol/Wire.h"
+#include "deskhub/session/LinkRecovery.h"
 #include "deskhub/session/client/ScreenClient.h"
 #include "deskhub/transport/Reassembler.h"
 #include "deskhub/ui/Strings.h"
@@ -40,7 +41,8 @@ enum class ClientPhase : int32_t { Idle = 0,
     Connecting = 1,
     Streaming = 2,
     Ended = 3,
-    Deciding = 4 };
+    Deciding = 4,
+    Reattaching = 5 };
 
 struct ScreenViewerConfig {
     NetAddr server{};
@@ -109,6 +111,8 @@ public:
         linkConfig.connectTimeoutMs = kHandshakeTimeoutMs;
         linkConfig.authTimeoutMs = kAuthTimeoutMs;
         linkConfig.recvWaitMs = 10;
+        linkConfig.recoverLink = true;
+        linkConfig.recoverGraceUs = deskhub::kViewerReattachGraceUs;
 
         HostLinkCallbacks linkHooks;
         linkHooks.onState = [this](HostLinkState state, std::string_view message) {
@@ -121,9 +125,15 @@ public:
         linkHooks.onStreamBroken = [this](uint64_t stream) {
             if (stream == kQuicFileStream && upload_) upload_->LinkLost();
         };
+        linkHooks.onReady = [this](bool resumed) {
+            if (resumed) relink_.store(true, std::memory_order_release);
+        };
 
         quit_.store(false);
         finished_.store(false);
+        reattaching_.store(false);
+        relink_.store(false);
+        endedNotified_.store(false);
         phase_.store(ClientPhase::Connecting, std::memory_order_release);
         {
             std::lock_guard<std::mutex> lk(textMutex_);
@@ -223,6 +233,10 @@ public:
     std::string StatusLine() {
         std::lock_guard<std::mutex> lk(textMutex_);
         return statusLine_;
+    }
+
+    deskhub::LinkPulseView LinkHealth() const {
+        return link_.Pulse();
     }
 
     std::string EndReason() {
@@ -444,10 +458,28 @@ private:
         return cfg_.hostLabel.empty() ? cfg_.server.ToString() : cfg_.hostLabel;
     }
 
+    void EnterReattach() {
+        if (reattaching_.exchange(true, std::memory_order_acq_rel)) return;
+        phase_.store(ClientPhase::Reattaching, std::memory_order_release);
+        {
+            std::lock_guard<std::mutex> lk(textMutex_);
+            statusLine_ = deskhub::ui::kTerminalReattaching;
+        }
+        if (cfg_.onStatus) cfg_.onStatus(deskhub::ui::kTerminalReattaching);
+    }
+
+    void NotifyEnded(const char* reason) {
+        if (endedNotified_.exchange(true, std::memory_order_acq_rel)) return;
+        if (cfg_.onEnded) cfg_.onEnded(reason && *reason ? reason : deskhub::ui::kDisconnected);
+    }
+
     void OnLinkState(HostLinkState state, std::string_view message) {
         switch (state) {
             case HostLinkState::Deciding:
                 phase_.store(ClientPhase::Deciding, std::memory_order_release);
+                return;
+            case HostLinkState::Recovering:
+                EnterReattach();
                 return;
             case HostLinkState::Connecting:
             case HostLinkState::Authing: {
@@ -511,12 +543,18 @@ private:
             if (reconfigured) rebuildDecoder_.store(true);
             if (cfg_.onParams) cfg_.onParams(np.width, np.height, np.fps);
         };
-        cb.onEnded = [this](const char* reason) {
+        cb.onEnded = [this](const char* reason, deskhub::ScreenSessionEnd cause) {
+            if (cause == deskhub::ScreenSessionEnd::Timeout && !quit_.load() &&
+                !link_.Settled()) {
+                EnterReattach();
+                link_.RequestRedial();
+                return;
+            }
             {
                 std::lock_guard<std::mutex> lk(textMutex_);
                 endReason_ = reason;
             }
-            if (cfg_.onEnded) cfg_.onEnded(reason ? reason : "disconnected");
+            NotifyEnded(reason);
             quit_.store(true);
         };
         cb.takeRenderedCount = [this] {
@@ -553,7 +591,7 @@ private:
                 if (endReason_.empty()) endReason_ = deskhub::ui::kTrustReject;
                 reason = endReason_;
             }
-            if (cfg_.onEnded) cfg_.onEnded(reason.c_str());
+            NotifyEnded(reason.c_str());
             if (cfg_.onFinished) cfg_.onFinished(reason.c_str());
             return;
         }
@@ -592,7 +630,11 @@ private:
             if (queueOverflow_.exchange(false, std::memory_order_acq_rel))
                 p.RequestKeyframe("q_overflow", now);
         };
-        hooks.beforeTick = [this, &batch](deskhub::ScreenClient& p, uint64_t now) {
+        hooks.beforeTick = [this, &batch, pcfg](deskhub::ScreenClient& p, uint64_t now) {
+            if (relink_.exchange(false, std::memory_order_acq_rel)) {
+                rebuildDecoder_.store(true);
+                p.Start(pcfg, now);
+            }
             input_.Drain(now, batch);
             for (const auto& e : batch) p.QueueInput(e);
             if (cfg_.alwaysFocused || input_.wantsFocus()) p.SetFocused(true);
@@ -604,13 +646,24 @@ private:
             if (clip) p.QueueClipboard(*clip);
         };
         hooks.onPhase = [this](bool streaming) {
-            phase_.store(streaming ? ClientPhase::Streaming : ClientPhase::Connecting,
+            if (streaming) {
+                reattaching_.store(false, std::memory_order_release);
+                phase_.store(ClientPhase::Streaming, std::memory_order_release);
+                return;
+            }
+            phase_.store(reattaching_.load(std::memory_order_acquire)
+                             ? ClientPhase::Reattaching
+                             : ClientPhase::Connecting,
                 std::memory_order_release);
         };
         hooks.onSocketError = [this] {
             LOGE("[Client] Socket error.");
             std::lock_guard<std::mutex> lk(textMutex_);
             if (endReason_.empty()) endReason_ = "socket error";
+        };
+        hooks.onSessionDead = [this] {
+            return reattaching_.load(std::memory_order_acquire) && !quit_.load() &&
+                   !link_.Settled();
         };
 
         RunScreenViewerLoop(
@@ -625,20 +678,16 @@ private:
         if (upload_) upload_->LinkLost();
         quit_.store(true);
         decCv_.notify_all();
+        std::string reason;
         {
             std::lock_guard<std::mutex> lk(textMutex_);
             if (endReason_.empty()) endReason_ = "stopped";
+            reason = endReason_;
         }
         phase_.store(ClientPhase::Ended, std::memory_order_release);
         finished_.store(true, std::memory_order_release);
-        if (cfg_.onFinished) {
-            std::string reason;
-            {
-                std::lock_guard<std::mutex> lk(textMutex_);
-                reason = endReason_;
-            }
-            cfg_.onFinished(reason.c_str());
-        }
+        NotifyEnded(reason.c_str());
+        if (cfg_.onFinished) cfg_.onFinished(reason.c_str());
         LOGI("[Client] Session ended.");
     }
 
@@ -656,6 +705,9 @@ private:
 
     std::atomic<bool> quit_{false};
     std::atomic<bool> finished_{false};
+    std::atomic<bool> reattaching_{false};
+    std::atomic<bool> relink_{false};
+    std::atomic<bool> endedNotified_{false};
     std::atomic<ClientPhase> phase_{ClientPhase::Idle};
 
     mutable std::mutex textMutex_;

--- a/platform/include/deskhubp/client/ScreenViewerLoop.h
+++ b/platform/include/deskhubp/client/ScreenViewerLoop.h
@@ -19,6 +19,7 @@ struct ScreenViewerLoopHooks {
     std::function<void(deskhub::ScreenClient&, uint64_t nowUs)> beforeTick;
     std::function<void(bool streaming)> onPhase;
     std::function<void()> onSocketError;
+    std::function<bool()> onSessionDead;
 };
 
 void RunScreenViewerLoop(const ScreenViewerRecv& recv, deskhub::ScreenClient& screen,

--- a/platform/include/deskhubp/ffi/ClientFfi.h
+++ b/platform/include/deskhubp/ffi/ClientFfi.h
@@ -21,7 +21,22 @@ typedef enum {
     DHPhaseStreaming = 2,
     DHPhaseEnded = 3,
     DHPhaseDeciding = 4,
+    DHPhaseReattaching = 5,
 } DHPhase;
+
+typedef enum {
+    DHLinkQualityUnknown = 0,
+    DHLinkQualityGood = 1,
+    DHLinkQualityFair = 2,
+    DHLinkQualityPoor = 3,
+} DHLinkQuality;
+
+typedef struct {
+    bool haveRtt;
+    uint32_t rttMs;
+    uint8_t lossPct;
+    DHLinkQuality quality;
+} DHLinkHealth;
 
 typedef struct {
     uint8_t sourceId;
@@ -247,7 +262,17 @@ typedef enum {
     DHStrTransferStopTakingButton = 150,
     DHStrConnectedPickSession = 151,
     DHStrConnectFirstHint = 152,
+    DHStrDisconnectButton = 153,
+    DHStrLinkQualityGood = 154,
+    DHStrLinkQualityFair = 155,
+    DHStrLinkQualityPoor = 156,
+    DHStrLinkNoReading = 157,
+    DHStrLinkReattaching = 158,
 } DHStringId;
+
+int dh_link_quality_text(DHLinkQuality quality, char* out, int capacity);
+
+int dh_link_ping_text(bool haveRtt, uint32_t rttMs, char* out, int capacity);
 
 const char* dh_string(DHStringId id);
 

--- a/platform/include/deskhubp/ffi/ScreenFfi.h
+++ b/platform/include/deskhubp/ffi/ScreenFfi.h
@@ -66,6 +66,8 @@ typedef struct {
 
 void dh_screen_snapshot(DHScreen* s, DHScreenState* out);
 
+void dh_screen_link_health(DHScreen* s, DHLinkHealth* out);
+
 DHPhase dh_screen_phase(DHScreen* s);
 const char* dh_screen_status_line(DHScreen* s);
 const char* dh_screen_end_reason(DHScreen* s);

--- a/platform/include/deskhubp/ffi/ScreenFfiForward.h
+++ b/platform/include/deskhubp/ffi/ScreenFfiForward.h
@@ -58,6 +58,17 @@
             engineOf(s).EndReason());                                                      \
     }                                                                                      \
                                                                                            \
+    void dh_screen_link_health(DHScreen* s, DHLinkHealth* out) {                           \
+        if (!out) return;                                                                  \
+        *out = DHLinkHealth{};                                                             \
+        if (!s) return;                                                                    \
+        const deskhub::LinkPulseView view = engineOf(s).LinkHealth();                      \
+        out->haveRtt = view.haveRtt;                                                       \
+        out->rttMs = (view.rttUs + 500) / 1000;                                            \
+        out->lossPct = view.lossPct;                                                       \
+        out->quality = DHLinkQuality(int(view.quality));                                   \
+    }                                                                                      \
+                                                                                           \
     DHPhase dh_screen_phase(DHScreen* s) {                                                 \
         if (!s) return DHPhaseIdle;                                                        \
         return DHPhase(int(engineOf(s).phase()));                                          \

--- a/platform/src/client/HostLink.cpp
+++ b/platform/src/client/HostLink.cpp
@@ -76,11 +76,14 @@ bool HostLink::Start(const HostLinkConfig& config, HostLinkCallbacks callbacks) 
     trustDecision_.store(int(TrustDecision::Pending), std::memory_order_release);
     authCode_.store(deskhub::AuthResultCode::NotPaired, std::memory_order_release);
     autoTrustPending_.store(false, std::memory_order_release);
+    redial_.store(false, std::memory_order_release);
+    pulse_.Reset();
     {
         const std::lock_guard<std::mutex> lock(mutex_);
         fingerprint_ = deskhub::Fingerprint{};
         verdict_ = deskhub::TrustVerdict::Unknown;
         message_.clear();
+        pulseView_ = deskhub::LinkPulseView{};
     }
     keepaliveIntervalUs_ = deskhub::KeepaliveIntervalUs(QuicSettings{}.idleTimeoutMs);
     linkLostAtUs_ = 0;
@@ -119,6 +122,15 @@ void HostLink::AcceptFingerprint() {
 
 void HostLink::RejectFingerprint() {
     trustDecision_.store(int(TrustDecision::Rejected), std::memory_order_release);
+}
+
+void HostLink::RequestRedial() {
+    redial_.store(true, std::memory_order_release);
+}
+
+deskhub::LinkPulseView HostLink::Pulse() const {
+    const std::lock_guard<std::mutex> lock(mutex_);
+    return pulseView_;
 }
 
 bool HostLink::Send(std::span<const uint8_t> message) {
@@ -173,6 +185,22 @@ void HostLink::NoteSent() {
     lastSendUs_.store(NowUs(), std::memory_order_relaxed);
 }
 
+void HostLink::SendLinkPing(uint64_t nowUs) {
+    uint8_t buf[deskhub::kMaxDatagram];
+    const size_t n = deskhub::BuildPing(buf, 0, pulse_.MakePing(nowUs));
+    if (n) Send(std::span<const uint8_t>(buf, n));
+    PublishPulse(nowUs);
+}
+
+void HostLink::PublishPulse(uint64_t nowUs) {
+    const deskhub::LinkPulseView view = pulse_.View(nowUs);
+    {
+        const std::lock_guard<std::mutex> lock(mutex_);
+        pulseView_ = view;
+    }
+    if (cb_.onPulse) cb_.onPulse(view);
+}
+
 void HostLink::Loop() {
     bool resumed = false;
     while (!stop_.load(std::memory_order_acquire)) {
@@ -182,6 +210,9 @@ void HostLink::Loop() {
             resumed ? deskhub::ui::kTerminalReattached : std::string_view{});
         linkLostAtUs_ = 0;
         redialAttempts_ = 0;
+        redial_.store(false, std::memory_order_release);
+        pulse_.Reset();
+        PublishPulse(NowUs());
         if (cb_.onReady) cb_.onReady(resumed);
 
         PumpReady();
@@ -353,8 +384,21 @@ void HostLink::PumpReady() {
         if (n < 0) return;
         if (n > 0 && from == config_.host) Route(std::span<const uint8_t>(buf, size_t(n)));
         if (peerGone_.load(std::memory_order_acquire)) return;
+        if (redial_.exchange(false, std::memory_order_acq_rel)) {
+            LOGW("link: a redial of %s was asked for \xE2\x80\x94 dropping this connection",
+                config_.host.ToString().c_str());
+            return;
+        }
 
         const uint64_t nowUs = NowUs();
+        if (pulse_.PingDue(nowUs)) SendLinkPing(nowUs);
+        if (config_.recoverLink && pulse_.Stalled(nowUs)) {
+            LOGW("link: no pong from %s for %llu ms \xE2\x80\x94 treating the link as lost",
+                config_.host.ToString().c_str(),
+                (unsigned long long)(deskhub::kLinkStallAfterUs / 1000));
+            return;
+        }
+
         const uint64_t lastSendUs = lastSendUs_.load(std::memory_order_relaxed);
         const uint64_t idleSinceUs = lastSendUs > lastKeepaliveUs ? lastSendUs : lastKeepaliveUs;
         if (deskhub::KeepaliveDue(nowUs, idleSinceUs, keepaliveIntervalUs_)) {
@@ -367,6 +411,11 @@ void HostLink::PumpReady() {
 void HostLink::Route(std::span<const uint8_t> message) {
     const std::optional<deskhub::CommonHeader> header = deskhub::ParseCommonHeader(message);
     if (!header || size_t(header->chan) >= deskhub::kChanCount) return;
+    if (header->type == deskhub::MsgType::Pong && header->sessionId == 0) {
+        const auto pong = deskhub::ParsePingPong(deskhub::PayloadOf(message));
+        if (pong && pulse_.OnPong(*pong, NowUs())) PublishPulse(NowUs());
+        return;
+    }
     const std::lock_guard<std::mutex> lock(routeMutex_);
     std::vector<std::weak_ptr<HostLinkChannel>>& lane = routes_[size_t(header->chan)];
     for (auto at = lane.begin(); at != lane.end();) {

--- a/platform/src/client/ScreenViewerLoop.cpp
+++ b/platform/src/client/ScreenViewerLoop.cpp
@@ -56,7 +56,7 @@ void RunScreenViewerLoop(const ScreenViewerRecv& recv, deskhub::ScreenClient& sc
         screen.PlanNacks(now);
         if (hooks.beforeTick) hooks.beforeTick(screen, now);
 
-        if (!screen.Tick(now)) break;
+        if (!screen.Tick(now) && !(hooks.onSessionDead && hooks.onSessionDead())) break;
         if (hooks.onPhase) hooks.onPhase(screen.streaming());
 
         screen.CountLoopBusy(now, NowUs());

--- a/platform/src/ffi/ClientFfi.cpp
+++ b/platform/src/ffi/ClientFfi.cpp
@@ -171,6 +171,12 @@ const char* dh_string(DHStringId id) {
         case DHStrTransferStopTakingButton: return deskhub::ui::kTransferStopTakingButton;
         case DHStrConnectedPickSession: return deskhub::ui::kConnectedPickSession;
         case DHStrConnectFirstHint: return deskhub::ui::kConnectFirstHint;
+        case DHStrDisconnectButton: return deskhub::ui::kDisconnectButton;
+        case DHStrLinkQualityGood: return deskhub::ui::kLinkQualityGood;
+        case DHStrLinkQualityFair: return deskhub::ui::kLinkQualityFair;
+        case DHStrLinkQualityPoor: return deskhub::ui::kLinkQualityPoor;
+        case DHStrLinkNoReading: return deskhub::ui::kLinkNoReading;
+        case DHStrLinkReattaching: return deskhub::ui::kTerminalReattaching;
         case DHStrOpenChoiceGroup: return deskhub::ui::kOpenChoiceGroup;
         case DHStrOpenDesktopLabel: return deskhub::ui::kOpenDesktopLabel;
         case DHStrOpenShellLabel: return deskhub::ui::kOpenShellLabel;
@@ -234,6 +240,20 @@ int dh_pairing_request_body(const char* name, const char* address, const char* s
 int dh_connecting_to(const char* address, char* out, int capacity) {
     if (!out || capacity <= 0) return 0;
     deskhubp::CopyToBuf(out, size_t(capacity), deskhub::ui::ConnectingTo(address ? address : ""));
+    return int(std::strlen(out));
+}
+
+int dh_link_quality_text(DHLinkQuality quality, char* out, int capacity) {
+    if (!out || capacity <= 0) return 0;
+    deskhubp::CopyToBuf(out, size_t(capacity),
+        deskhub::ui::LinkQualityText(deskhub::LinkQuality(quality)));
+    return int(std::strlen(out));
+}
+
+int dh_link_ping_text(bool haveRtt, uint32_t rttMs, char* out, int capacity) {
+    if (!out || capacity <= 0) return 0;
+    deskhubp::CopyToBuf(out, size_t(capacity),
+        haveRtt ? deskhub::ui::PingMs(rttMs) : std::string(deskhub::ui::kLinkNoReading));
     return int(std::strlen(out));
 }
 

--- a/platform/tests/session/HostLinkTests.cpp
+++ b/platform/tests/session/HostLinkTests.cpp
@@ -2,6 +2,8 @@
 #include "support/TestSupport.h"
 
 #include "deskhub/protocol/Wire.h"
+#include "deskhub/session/LinkPulse.h"
+#include "deskhub/session/host/Beacon.h"
 #include "deskhub/ui/Strings.h"
 #include "deskhubp/net/SessionTransport.h"
 #include "deskhubp/auth/AuthNegotiation.h"
@@ -40,8 +42,10 @@ std::vector<uint8_t> TerminalProbe() {
 
 struct LinkHostRig {
     deskhubp::SessionTransport sock{};
+    deskhub::Beacon beacon{};
     std::thread pump{};
     std::atomic<bool> stop{false};
+    std::atomic<bool> answerPings{true};
     std::atomic<int> terminalSeen{0};
 
     ~LinkHostRig() {
@@ -64,15 +68,22 @@ struct LinkHostRig {
         stop.store(false, std::memory_order_release);
         pump = std::thread([this] {
             uint8_t buf[deskhub::kMaxRecordSize];
+            uint8_t reply[deskhub::kMaxDatagram];
             while (!stop.load(std::memory_order_acquire)) {
                 NetAddr from;
                 const int n = sock.RecvFrom(buf, sizeof(buf), from);
                 if (n <= 0) continue;
                 const std::span<const uint8_t> message(buf, size_t(n));
                 const auto header = deskhub::ParseCommonHeader(message);
-                if (!header || header->chan != deskhub::Chan::Terminal) continue;
-                terminalSeen.fetch_add(1, std::memory_order_relaxed);
-                sock.SendRecordOn(from, deskhubp::kQuicControlStream, message);
+                if (!header) continue;
+                if (header->chan == deskhub::Chan::Terminal) {
+                    terminalSeen.fetch_add(1, std::memory_order_relaxed);
+                    sock.SendRecordOn(from, deskhubp::kQuicControlStream, message);
+                    continue;
+                }
+                if (!answerPings.load(std::memory_order_acquire)) continue;
+                if (const size_t rn = beacon.Reply(reply, message, sock.Authenticated(from)); rn)
+                    sock.SendTo(from, reply, rn);
             }
         });
         return true;
@@ -253,6 +264,104 @@ void TestALinkRecoversAndSaysItResumed() {
     host->Shutdown();
 }
 
+void TestTheLinkTakesItsOwnPulse() {
+    std::printf("[hostlink] the link pings on its own and reads out rtt and quality...\n");
+    const deskhubp::HostIdentity identity = deskhubp::LoadOrCreateHostIdentity("link-test-host");
+    LinkHostRig host;
+    Check(host.Start(identity), "the host rig listens");
+
+    std::atomic<bool> pulseSeen{false};
+    deskhubp::HostLink link;
+    deskhubp::HostLinkCallbacks hooks;
+    hooks.onPulse = [&pulseSeen](const deskhub::LinkPulseView& view) {
+        if (view.haveRtt) pulseSeen.store(true, std::memory_order_release);
+    };
+    Check(link.Start(LinkConfig(kLinkPasscode), std::move(hooks)), "the link starts");
+    Check(WaitUntil([&pulseSeen] { return pulseSeen.load(std::memory_order_acquire); }, 10000),
+        "a pong turns into a reading inside the deadline");
+
+    const deskhub::LinkPulseView view = link.Pulse();
+    Check(view.haveRtt, "the accessor hands out the same reading");
+    Check(view.quality != deskhub::LinkQuality::Unknown, "and a verdict on the quality");
+    Check(view.rttUs < 1'000'000, "loopback reads as under a second");
+
+    link.Stop();
+    host.Shutdown();
+}
+
+void TestARequestedRedialResumes() {
+    std::printf("[hostlink] asking for a redial drops the link and brings it back...\n");
+    const deskhubp::HostIdentity identity = deskhubp::LoadOrCreateHostIdentity("link-test-host");
+    LinkHostRig host;
+    Check(host.Start(identity), "the host rig listens");
+
+    deskhubp::HostLinkConfig config = LinkConfig(kLinkPasscode);
+    config.recoverLink = true;
+    config.recoverGraceUs = uint64_t{30} * 1000 * 1000;
+
+    std::atomic<bool> lostSeen{false};
+    std::atomic<bool> resumedSeen{false};
+    deskhubp::HostLink link;
+    deskhubp::HostLinkCallbacks hooks;
+    hooks.onLinkLost = [&lostSeen] { lostSeen.store(true, std::memory_order_release); };
+    hooks.onReady = [&resumedSeen](bool resumed) {
+        if (resumed) resumedSeen.store(true, std::memory_order_release);
+    };
+    Check(link.Start(config, std::move(hooks)), "the link starts");
+    Check(WaitUntil([&link] { return link.State() == deskhubp::HostLinkState::Ready; }, 10000),
+        "the link is admitted");
+
+    link.RequestRedial();
+    Check(WaitUntil([&lostSeen] { return lostSeen.load(std::memory_order_acquire); }, 10000),
+        "the redial request drops the connection");
+    Check(WaitUntil([&resumedSeen] { return resumedSeen.load(std::memory_order_acquire); },
+              20000),
+        "and the link comes back on its own");
+    Check(link.State() == deskhubp::HostLinkState::Ready, "ready again");
+
+    link.Stop();
+    host.Shutdown();
+}
+
+void TestAHostThatStopsAnsweringPingsReadsAsLost() {
+    std::printf("[hostlink] a host that goes silent on pings is treated as lost...\n");
+    const deskhubp::HostIdentity identity = deskhubp::LoadOrCreateHostIdentity("link-test-host");
+    LinkHostRig host;
+    Check(host.Start(identity), "the host rig listens");
+
+    deskhubp::HostLinkConfig config = LinkConfig(kLinkPasscode);
+    config.recoverLink = true;
+    config.recoverGraceUs = uint64_t{30} * 1000 * 1000;
+
+    std::atomic<bool> pulseSeen{false};
+    std::atomic<bool> lostSeen{false};
+    std::atomic<bool> resumedSeen{false};
+    deskhubp::HostLink link;
+    deskhubp::HostLinkCallbacks hooks;
+    hooks.onPulse = [&pulseSeen](const deskhub::LinkPulseView& view) {
+        if (view.haveRtt) pulseSeen.store(true, std::memory_order_release);
+    };
+    hooks.onLinkLost = [&lostSeen] { lostSeen.store(true, std::memory_order_release); };
+    hooks.onReady = [&resumedSeen](bool resumed) {
+        if (resumed) resumedSeen.store(true, std::memory_order_release);
+    };
+    Check(link.Start(config, std::move(hooks)), "the link starts");
+    Check(WaitUntil([&pulseSeen] { return pulseSeen.load(std::memory_order_acquire); }, 10000),
+        "pongs are flowing first");
+
+    host.answerPings.store(false, std::memory_order_release);
+    Check(WaitUntil([&lostSeen] { return lostSeen.load(std::memory_order_acquire); }, 15000),
+        "the silence is called out as a lost link");
+
+    host.answerPings.store(true, std::memory_order_release);
+    Check(WaitUntil([&resumedSeen] { return resumedSeen.load(std::memory_order_acquire); },
+              20000),
+        "and answering again brings the link back");
+
+    link.Stop();
+    host.Shutdown();
+}
+
 }
 
 void RunHostLinkTests() {
@@ -260,4 +369,7 @@ void RunHostLinkTests() {
     TestALinkStopsOnAChangedKeyUntilAccepted();
     TestALinkReportsARefusal();
     TestALinkRecoversAndSaysItResumed();
+    TestTheLinkTakesItsOwnPulse();
+    TestARequestedRedialResumes();
+    TestAHostThatStopsAnsweringPingsReadsAsLost();
 }


### PR DESCRIPTION
After connecting, every client now shows where it is connected and how the link is doing, with a disconnect control and automatic reattach.

- `core/session/LinkPulse`: once admitted, `HostLink` pings the host once a second with a session-0 datagram the beacon already answers — no wire change, no new message type; a host too old to answer leaves the reading at Unknown. Echoed timestamps become a smoothed RTT, unanswered pings a loss percentage, and the two fold into Good / Fair / Poor. The ping doubles as the keepalive, and on a recovering link five silent seconds (only ever after a first pong) drop the connection into the existing redial path — the terminal now notices a dead host in ~5 s instead of QUIC's 30 s idle timeout.
- The screen viewer opts into link recovery like the terminal always has: a session that stops receiving parks the window in a new `Reattaching` phase (last frame up, status line says so), forces a redial, re-runs HELLO with the same client id once readmitted, and resumes off the fresh keyframe. Sixty seconds without getting back in — or a deliberate BYE/refusal — ends the window with the reason.
- UI: macOS gets a status bar above the video (quality dot, ping, address, Disconnect); iOS and Android show the reading in the floating control panel with a reattaching banner; Linux adds the reading and a Disconnect button to the header bar; Windows appends it to the title, where closing the window already disconnects. New FFI: `dh_screen_link_health`, `dh_link_quality_text`, `dh_link_ping_text`, string ids 153–158, `DHPhaseReattaching`.
- Spec rows V-7/V-8 and architecture §5 updated, both languages.

Verified with `make test-all` (three new HostLink tests: pulse over loopback QUIC, requested redial, silent host treated as lost), `make lint`, `make lint-tidy`, core coverage 96.98% lines / 88.11% branches (`LinkPulse.cpp` at 100%), `make build-macos`, `make build-android`. The Linux and Windows clients were not compiled locally (no toolchain on this machine) — CI covers them.