### PR TITLE
chore(ios): split the stream control panel out of StreamView

### DIFF
--- a/client/ios/app/swift/StreamOverlays.swift
+++ b/client/ios/app/swift/StreamOverlays.swift
@@ -78,3 +78,124 @@ struct ZoomControls: View {
         .buttonStyle(.plain)
     }
 }
+
+struct StreamControlPanel: View {
+    let session: AppModel
+    let model: StreamModel
+    let streaming: Bool
+    @Binding var isOpen: Bool
+    @Binding var keyboardOn: Bool
+    @State private var pickerOpen = false
+
+    var body: some View {
+        if isOpen {
+            panel
+        } else {
+            openButton
+        }
+    }
+
+    private var hostTitle: String {
+        DeskhubClient.hostTitle(
+            model.address, width: model.videoWidth, height: model.videoHeight
+        )
+    }
+
+    private var openButton: some View {
+        Button {
+            withAnimation(.easeOut(duration: 0.18)) { isOpen = true }
+        } label: {
+            Image(systemName: "slider.horizontal.3")
+                .font(.system(size: 17, weight: .semibold))
+                .foregroundStyle(.white)
+                .frame(width: 44, height: 44)
+                .background(.black.opacity(0.45), in: Circle())
+                .overlay(Circle().strokeBorder(.white.opacity(0.25), lineWidth: 1))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Show controls")
+    }
+
+    private var panel: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            header
+            hotkeyStrip
+            actions
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity)
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 16))
+        .confirmationDialog("Display", isPresented: $pickerOpen, titleVisibility: .visible) {
+            ForEach(session.sources) { source in
+                Button(sourceLabel(source)) { session.switchSource(to: source.id) }
+            }
+            Button("Cancel", role: .cancel) {}
+        }
+    }
+
+    private var header: some View {
+        HStack(alignment: .top, spacing: 8) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(hostTitle)
+                    .font(.caption)
+                    .foregroundStyle(.white)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                if streaming, !model.statusLine.isEmpty {
+                    Text(model.statusLine)
+                        .font(.caption)
+                        .foregroundStyle(.white.opacity(0.8))
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.75)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            Button {
+                withAnimation(.easeOut(duration: 0.18)) { isOpen = false }
+            } label: {
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(.white)
+                    .frame(width: 32, height: 32)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Hide controls")
+        }
+    }
+
+    private var hotkeyStrip: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                ForEach(kHotkeys, id: \.label) { hotkey in
+                    Button(hotkey.label) { model.hotkey(hotkey) }
+                        .buttonStyle(.bordered)
+                }
+            }
+            .padding(.vertical, 1)
+        }
+        .disabled(!streaming)
+        .opacity(streaming ? 1 : 0.45)
+    }
+
+    private var actions: some View {
+        HStack(spacing: 10) {
+            Button(keyboardOn ? "Hide keyboard" : "Keyboard") { keyboardOn.toggle() }
+                .buttonStyle(.bordered)
+                .disabled(!streaming)
+
+            if session.sources.count > 1 {
+                Button("Display") { pickerOpen = true }
+                    .buttonStyle(.bordered)
+            }
+
+            Spacer()
+        }
+    }
+
+    private func sourceLabel(_ source: Source) -> String {
+        let mark = source.id == model.sourceId ? "✓ " : ""
+        return mark + source.pickerLabel
+    }
+}

--- a/client/ios/app/swift/StreamView.swift
+++ b/client/ios/app/swift/StreamView.swift
@@ -8,7 +8,6 @@ struct StreamView: View {
     @Environment(\.scenePhase) private var scenePhase
     @State private var layer: AVSampleBufferDisplayLayer?
     @State private var keyboardOn = false
-    @State private var pickerOpen = false
 
     @State private var controlsOpen = false
 
@@ -107,12 +106,6 @@ struct StreamView: View {
         .statusBarHidden()
     }
 
-    private var hostTitle: String {
-        DeskhubClient.hostTitle(
-            model.address, width: model.videoWidth, height: model.videoHeight
-        )
-    }
-
     private var videoArea: some View {
         GeometryReader { proxy in
             let viewport = proxy.size
@@ -170,11 +163,13 @@ struct StreamView: View {
                     }
                 )
             }
-            if controlsOpen {
-                controlPanel
-            } else {
-                openButton
-            }
+            StreamControlPanel(
+                session: session,
+                model: model,
+                streaming: streaming,
+                isOpen: $controlsOpen,
+                keyboardOn: $keyboardOn
+            )
         }
         .padding(12)
         .background(
@@ -185,94 +180,6 @@ struct StreamView: View {
                     }
             }
         )
-    }
-
-    private var openButton: some View {
-        Button {
-            withAnimation(.easeOut(duration: 0.18)) { controlsOpen = true }
-        } label: {
-            Image(systemName: "slider.horizontal.3")
-                .font(.system(size: 17, weight: .semibold))
-                .foregroundStyle(.white)
-                .frame(width: 44, height: 44)
-                .background(.black.opacity(0.45), in: Circle())
-                .overlay(Circle().strokeBorder(.white.opacity(0.25), lineWidth: 1))
-        }
-        .buttonStyle(.plain)
-        .accessibilityLabel("Show controls")
-    }
-
-    private var controlPanel: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            HStack(alignment: .top, spacing: 8) {
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(hostTitle)
-                        .font(.caption)
-                        .foregroundStyle(.white)
-                        .lineLimit(1)
-                        .truncationMode(.middle)
-                    if streaming, !model.statusLine.isEmpty {
-                        Text(model.statusLine)
-                            .font(.caption)
-                            .foregroundStyle(.white.opacity(0.8))
-                            .lineLimit(1)
-                            .minimumScaleFactor(0.75)
-                    }
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-
-                Button {
-                    withAnimation(.easeOut(duration: 0.18)) { controlsOpen = false }
-                } label: {
-                    Image(systemName: "chevron.down")
-                        .font(.system(size: 13, weight: .semibold))
-                        .foregroundStyle(.white)
-                        .frame(width: 32, height: 32)
-                        .contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel("Hide controls")
-            }
-
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: 8) {
-                    ForEach(kHotkeys, id: \.label) { hotkey in
-                        Button(hotkey.label) { model.hotkey(hotkey) }
-                            .buttonStyle(.bordered)
-                    }
-                }
-                .padding(.vertical, 1)
-            }
-            .disabled(!streaming)
-            .opacity(streaming ? 1 : 0.45)
-
-            HStack(spacing: 10) {
-                Button(keyboardOn ? "Hide keyboard" : "Keyboard") { keyboardOn.toggle() }
-                    .buttonStyle(.bordered)
-                    .disabled(!streaming)
-
-                if session.sources.count > 1 {
-                    Button("Display") { pickerOpen = true }
-                        .buttonStyle(.bordered)
-                }
-
-                Spacer()
-            }
-        }
-        .padding(12)
-        .frame(maxWidth: .infinity)
-        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 16))
-        .confirmationDialog("Display", isPresented: $pickerOpen, titleVisibility: .visible) {
-            ForEach(session.sources) { source in
-                Button(sourceLabel(source)) { session.switchSource(to: source.id) }
-            }
-            Button("Cancel", role: .cancel) {}
-        }
-    }
-
-    private func sourceLabel(_ source: Source) -> String {
-        let mark = source.id == model.sourceId ? "✓ " : ""
-        return mark + source.pickerLabel
     }
 
     private func releaseLayer() {


### PR DESCRIPTION
StreamView had grown past the SwiftLint type_body_length limit, turning every lint run red. The panel is a self-contained overlay, so it joins the other two in StreamOverlays.swift.