### PR TITLE
Keep the picture moving after a lost packet

### DIFF
--- a/client/android/app/src/main/cpp/SharingHost.cpp
+++ b/client/android/app/src/main/cpp/SharingHost.cpp
@@ -168,11 +168,14 @@ bool SharingHost::Start(const std::vector<ShareSource>& sources, const ShareOpti
         return target;
     };
 
-    policy.source.applyQualityStep = [](deskhubp::HostSource& st, const deskhub::QualityStep&,
-                                         const deskhub::QualityStep&) {
+    policy.source.applyQualityStep = [](deskhubp::HostSource& st,
+                                         const deskhub::QualityStep& prev,
+                                         const deskhub::QualityStep& next) {
         SourcePipeline& p = Pipeline(st);
         const deskhub::StreamSize target = PlanStreamSize(p);
-        RebuildLocked(p);
+        std::lock_guard<std::mutex> lk(p.encMutex);
+        if (prev.fps != next.fps && p.encoder) p.encoder->SetFps(next.fps);
+        RebuildPipeline(p);
         return target;
     };
 

--- a/client/android/app/src/main/cpp/encode/MediaCodecEncoder.cpp
+++ b/client/android/app/src/main/cpp/encode/MediaCodecEncoder.cpp
@@ -111,6 +111,13 @@ bool MediaCodecEncoder::SetBitrate(uint32_t bitrateBps) {
     return true;
 }
 
+bool MediaCodecEncoder::SetFps(uint32_t fps) {
+    if (!codec_ || !fps || fps == cfg_.fps) return codec_ != nullptr;
+    cfg_.fps = fps;
+    SetParameter("max-fps-to-encoder", int32_t(fps));
+    return SetBitrate(cfg_.bitrateBps);
+}
+
 void MediaCodecEncoder::ApplyPendingSyncRequest() {
     if (!syncRequested_.exchange(false, std::memory_order_acq_rel)) return;
     SetParameter("request-sync", 0);

--- a/client/android/app/src/main/cpp/encode/MediaCodecEncoder.h
+++ b/client/android/app/src/main/cpp/encode/MediaCodecEncoder.h
@@ -25,6 +25,8 @@ public:
 
     bool SetBitrate(uint32_t bitrateBps);
 
+    bool SetFps(uint32_t fps);
+
     void Finish();
 
     bool IsOpen() const {
@@ -59,3 +61,5 @@ private:
 
 static_assert(deskhub::media::VideoEncoderLike<MediaCodecEncoder, void*>,
     "MediaCodecEncoder must match the shared encoder signature");
+static_assert(deskhub::media::HotFpsEncoder<MediaCodecEncoder>,
+    "the virtual display feeds the input surface, so a frame-rate step must not rebuild the codec");

--- a/client/windows/cpp/decode/PanelRenderer.cpp
+++ b/client/windows/cpp/decode/PanelRenderer.cpp
@@ -4,6 +4,7 @@
 
 #include <d3d11_1.h>
 #include <dxgi1_2.h>
+#include <dxgi1_5.h>
 #include <wrl/client.h>
 #include <cstdio>
 #include <mutex>
@@ -29,6 +30,25 @@ struct PanelRenderer::Impl {
     std::mutex renderMutex;
     uint32_t bbW = 0, bbH = 0;
     uint32_t vpSrcW = 0, vpSrcH = 0;
+    bool tearingAllowed = false;
+
+    static bool TearingSupported(IDXGIFactory2* factory) {
+        ComPtr<IDXGIFactory5> factory5;
+        if (FAILED(factory->QueryInterface(IID_PPV_ARGS(&factory5)))) return false;
+        BOOL allowed = FALSE;
+        if (FAILED(factory5->CheckFeatureSupport(DXGI_FEATURE_PRESENT_ALLOW_TEARING, &allowed,
+                sizeof(allowed))))
+            return false;
+        return allowed != FALSE;
+    }
+
+    UINT SwapChainFlags() const {
+        return tearingAllowed ? UINT(DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING) : 0u;
+    }
+
+    UINT PresentFlags() const {
+        return tearingAllowed ? UINT(DXGI_PRESENT_ALLOW_TEARING) : 0u;
+    }
 
     bool Init(ID3D11Device* dev, HWND hwnd, uint32_t initialW, uint32_t initialH) {
         if (!hwnd) return false;
@@ -52,6 +72,8 @@ struct PanelRenderer::Impl {
             if (SUCCEEDED(dxgiDev.As(&dxgiDev1))) dxgiDev1->SetMaximumFrameLatency(1);
         }
 
+        tearingAllowed = TearingSupported(factory.Get());
+
         DXGI_SWAP_CHAIN_DESC1 sd{};
         sd.Width = bbW;
         sd.Height = bbH;
@@ -62,6 +84,7 @@ struct PanelRenderer::Impl {
         sd.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
         sd.Scaling = DXGI_SCALING_STRETCH;
         sd.AlphaMode = DXGI_ALPHA_MODE_IGNORE;
+        sd.Flags = SwapChainFlags();
         PR_CHECK(factory->CreateSwapChainForHwnd(device.Get(), hwnd, &sd, nullptr, nullptr,
                      &swapchain),
             "CreateSwapChainForHwnd");
@@ -75,7 +98,8 @@ struct PanelRenderer::Impl {
     bool Resize(uint32_t w, uint32_t h) {
         backbuffer.Reset();
         vp.Reset();
-        PR_CHECK(swapchain->ResizeBuffers(0, w, h, DXGI_FORMAT_UNKNOWN, 0), "ResizeBuffers");
+        PR_CHECK(swapchain->ResizeBuffers(0, w, h, DXGI_FORMAT_UNKNOWN, SwapChainFlags()),
+            "ResizeBuffers");
         PR_CHECK(swapchain->GetBuffer(0, IID_PPV_ARGS(&backbuffer)), "GetBuffer(resize)");
         bbW = w;
         bbH = h;
@@ -110,7 +134,7 @@ struct PanelRenderer::Impl {
 
         if (!vp.Blt(tex, subresource)) return false;
         if (outReadyUs) *outReadyUs = NowUs();
-        PR_CHECK(swapchain->Present(0, 0), "Present");
+        PR_CHECK(swapchain->Present(0, PresentFlags()), "Present");
         return true;
     }
 };

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -117,6 +117,7 @@ if(DESKHUB_CORE_TESTS)
         tests/transport/FecTests.cpp
         tests/transport/RetransmitCacheTests.cpp
         tests/transport/PacerTests.cpp
+        tests/transport/LossGoodputTests.cpp
 
         tests/session/ScreenSessionTests.cpp
         tests/session/ScreenClientTests.cpp

--- a/core/include/deskhub/control/BitrateController.h
+++ b/core/include/deskhub/control/BitrateController.h
@@ -14,6 +14,8 @@ struct BitrateDecision {
 
 class BitrateController {
 public:
+    static constexpr int kCleanSecondsBeforeDroppingFec = 10;
+
     BitrateController(uint32_t startBps, uint32_t minBps)
         : cur_(startBps), max_(startBps), min_(minBps) {}
 
@@ -37,7 +39,7 @@ private:
 
     uint64_t lastDecreaseUs_ = 0;
     int cleanSeconds_ = 0;
-    bool fec_ = false;
+    bool fec_ = true;
 };
 
 }

--- a/core/include/deskhub/session/host/SourcePipelineState.h
+++ b/core/include/deskhub/session/host/SourcePipelineState.h
@@ -49,7 +49,7 @@ struct SourcePipelineState {
 
     std::atomic<bool> sizeChanged{false};
     std::atomic<bool> qualityChanged{false};
-    std::atomic<bool> wantFec{false};
+    std::atomic<bool> wantFec{true};
     std::atomic<bool> netReady{false};
     std::atomic<bool> failed{false};
     std::atomic<bool> paused{false};

--- a/core/include/deskhub/transport/Reassembler.h
+++ b/core/include/deskhub/transport/Reassembler.h
@@ -38,6 +38,8 @@ public:
 
     std::function<void(const FrameDropInfo&)> onFrameDrop;
 
+    std::function<void(uint32_t frameId)> onReferenceLost;
+
     struct Stats {
         uint64_t packetsReceived = 0;
         uint64_t fecReceived = 0;
@@ -61,6 +63,10 @@ public:
 
     void SetFps(uint32_t fps) {
         if (fps) frameIntervalUs_ = 1'000'000ull / fps;
+    }
+
+    void SetRttUs(uint64_t rttUs) {
+        rttUs_ = rttUs;
     }
 
     void Push(const VideoPacketView& pkt, uint64_t nowUs);
@@ -115,12 +121,19 @@ private:
 
     static constexpr uint64_t kStallTimeoutMultiple = 2;
     static constexpr uint64_t kHardTimeoutMultiple = 30;
+    static constexpr uint64_t kRetransmitRttMultiple = 3;
+    static constexpr uint64_t kRetransmitRttDivisor = 2;
 
     static constexpr uint64_t kNackHoldUs = 2'000;
     static constexpr uint64_t kNackMinIntervalUs = 10'000;
 
     uint64_t StallTimeoutUs() const {
-        return kStallTimeoutMultiple * frameIntervalUs_;
+        const uint64_t paced = kStallTimeoutMultiple * frameIntervalUs_;
+        const uint64_t retransmit =
+            kNackHoldUs + rttUs_ * kRetransmitRttMultiple / kRetransmitRttDivisor;
+        const uint64_t wait = paced > retransmit ? paced : retransmit;
+        const uint64_t hard = HardTimeoutUs();
+        return wait < hard ? wait : hard;
     }
     uint64_t HardTimeoutUs() const {
         return kHardTimeoutMultiple * frameIntervalUs_;
@@ -128,6 +141,7 @@ private:
 
     PendingMap pending_;
     uint64_t frameIntervalUs_;
+    uint64_t rttUs_ = 0;
     bool waitingForIdr_ = true;
     bool lossEvent_ = false;
     bool haveBarrier_ = false;

--- a/core/src/control/BitrateController.cpp
+++ b/core/src/control/BitrateController.cpp
@@ -9,7 +9,7 @@ BitrateDecision BitrateController::Update(const Feedback& fb, uint64_t nowUs) {
     if (fb.lossPct >= 1) {
         cleanSeconds_ = 0;
         fec_ = true;
-    } else if (++cleanSeconds_ >= 5) {
+    } else if (++cleanSeconds_ >= kCleanSecondsBeforeDroppingFec) {
         fec_ = false;
     }
     d.fecEnabled = fec_;

--- a/core/src/session/client/ScreenClient.cpp
+++ b/core/src/session/client/ScreenClient.cpp
@@ -33,6 +33,7 @@ ScreenClientSessionCallbacks ScreenClient::MakeSessionCallbacks() {
     };
     sc.onRtt = [this](uint32_t rttUs) {
         diag_.minRttUs.Add(rttUs);
+        if (reasm_) reasm_->SetRttUs(diag_.minRttUs.value());
     };
     sc.onClipboardText = [this](std::string_view text) {
         if (cb_.onClipboardText) cb_.onClipboardText(text);
@@ -73,6 +74,10 @@ void ScreenClient::EnsureReassembler() {
         char drop[diag::ScreenClientDiag::kFrameDropBufBytes];
         LogWarn(diag::ScreenClientDiag::FormatFrameDrop(drop, sizeof(drop), d));
     };
+    reasm_->onReferenceLost = [this](uint32_t frameId) {
+        session_.SendInvalidateRef(frameId);
+    };
+    reasm_->SetRttUs(diag_.minRttUs.value());
 }
 
 void ScreenClient::OnDatagram(std::span<const uint8_t> pkt, uint64_t nowUs) {

--- a/core/src/transport/Reassembler.cpp
+++ b/core/src/transport/Reassembler.cpp
@@ -232,7 +232,6 @@ void Reassembler::Drop(PendingMap::iterator it, DropReason reason, uint64_t nowU
 
         lossEvent_ = true;
         ++stats_.lossEvents;
-        waitingForIdr_ = true;
     } else {
         ++stats_.framesSkipped;
     }
@@ -240,9 +239,11 @@ void Reassembler::Drop(PendingMap::iterator it, DropReason reason, uint64_t nowU
         haveBarrier_ = true;
         barrierId_ = it->first;
     }
+    const uint32_t droppedId = it->first;
     pending_.erase(it);
 
     if (onFrameDrop) onFrameDrop(info);
+    if (loss && onReferenceLost) onReferenceLost(droppedId);
 }
 
 void Reassembler::NoteLatePacket(uint32_t id, uint64_t nowUs) {

--- a/core/tests/TestMain.cpp
+++ b/core/tests/TestMain.cpp
@@ -24,6 +24,7 @@ int main() {
 
     std::printf("--- transport: send pacer ---\n");
     RunPacerTests();
+    RunLossGoodputTests();
 
     std::printf("--- session ---\n");
     RunScreenSessionTests();

--- a/core/tests/Tests.h
+++ b/core/tests/Tests.h
@@ -6,6 +6,7 @@ void RunAudioJitterBufferTests();
 void RunFecTests();
 void RunRetransmitCacheTests();
 void RunPacerTests();
+void RunLossGoodputTests();
 void RunScreenSessionTests();
 void RunScreenClientTests();
 void RunClipboardSyncTests();

--- a/core/tests/control/ControlTests.cpp
+++ b/core/tests/control/ControlTests.cpp
@@ -76,26 +76,26 @@ void TestBitrateUncommitted() {
 }
 
 void TestFecHysteresis() {
-    std::printf("[ctrl] FEC: on immediately, off only after 5 clean seconds...\n");
+    std::printf("[ctrl] FEC: armed from the first frame, off only after a long clean run...\n");
+    const int clean = BitrateController::kCleanSecondsBeforeDroppingFec;
     BitrateController c(20'000'000, 1'000'000);
+    Check(c.fecEnabled(), "a link with no measurements yet is assumed to need FEC");
 
-    auto d = c.Update(Fb(0), 1'000'000);
-    Check(!d.fecEnabled && !d.fecToggled, "FEC starts off and stays off on a clean link");
-
-    d = c.Update(Fb(3), 2'000'000);
-    Check(d.fecEnabled && d.fecToggled, "any real loss turns FEC on at once");
-
-    uint64_t now = 3'000'000;
-    for (int i = 0; i < 4; ++i, now += 1'000'000) {
+    uint64_t now = 1'000'000;
+    BitrateDecision d{};
+    for (int i = 0; i < clean - 1; ++i, now += 1'000'000) {
         d = c.Update(Fb(0), now);
-        Check(d.fecEnabled && !d.fecToggled, "FEC stays on through 4 clean seconds");
+        Check(d.fecEnabled && !d.fecToggled, "FEC stays on through the clean run");
     }
     d = c.Update(Fb(0), now);
-    Check(!d.fecEnabled && d.fecToggled, "FEC turns off on the 5th clean second");
+    Check(!d.fecEnabled && d.fecToggled, "FEC turns off once the link has proved itself");
 
-    c.Update(Fb(4), now + 1'000'000);
-    now += 2'000'000;
-    for (int i = 0; i < 4; ++i, now += 1'000'000) c.Update(Fb(0), now);
+    now += 1'000'000;
+    d = c.Update(Fb(3), now);
+    Check(d.fecEnabled && d.fecToggled, "any real loss turns FEC back on at once");
+
+    now += 1'000'000;
+    for (int i = 0; i < clean - 1; ++i, now += 1'000'000) c.Update(Fb(0), now);
     Check(c.fecEnabled(), "clean-second counter restarts after a fresh loss");
 }
 

--- a/core/tests/session/SourcePipelineStateTests.cpp
+++ b/core/tests/session/SourcePipelineStateTests.cpp
@@ -21,7 +21,7 @@ void TestAFreshSourceIsReadyToStream() {
     Check(!st.failed.load(), "a new source is not failed");
     Check(!st.shutdownDone, "a new source has not been shut down");
     Check(!st.netReady.load(), "but it is not on the wire until the capture side says so");
-    Check(!st.wantFec.load(), "FEC starts off and is turned on only by measured loss");
+    Check(st.wantFec.load(), "FEC is armed up front, before any loss has been measured");
     Check(!st.forceIdr.load(), "no keyframe is owed before a client has asked for one");
     Check(!st.haveFeedback.load(), "no link numbers are claimed before the client reports any");
     Check(st.replyPacked.load() == 0, "there is no reply address until a datagram arrives");
@@ -37,7 +37,7 @@ void TestTheStartingBitrateIsTheOneThatWasAskedFor() {
         "the bitrate the UI shows is the bitrate the encoder was configured with");
     Check(st.rate.bitrateBps() == kStartBps,
         "the controller starts from the same number, so the first feedback is not a jump");
-    Check(!st.rate.fecEnabled(), "and it agrees with wantFec that FEC is off");
+    Check(st.rate.fecEnabled(), "and it agrees with wantFec that FEC is armed");
 }
 
 void TestCountersStartAtZero() {

--- a/core/tests/session/ViewerFeedbackTests.cpp
+++ b/core/tests/session/ViewerFeedbackTests.cpp
@@ -124,18 +124,14 @@ void TestAcceptedBitrateIsCommittedOnce() {
 }
 
 void TestFecFollowsLoss() {
-    std::printf("[hostfb] FEC is switched on by loss and reported only on the edge...\n");
+    std::printf("[hostfb] FEC is armed up front and reported only on the edge...\n");
     SourcePipelineState st(kStartBps, kMinBps);
     Recorder r;
-    Check(!st.wantFec.load(), "off to begin with");
+    Check(st.wantFec.load(), "armed to begin with");
 
     FeedbackOutcome out = ApplyFeedback(st, LossyLink(10), kT0 + 1'000'000, r.Hooks());
-    Check(out.fecToggled && out.fecEnabled, "loss turns it on and says so");
+    Check(!out.fecToggled, "loss on an already-armed link is not an edge");
     Check(st.wantFec.load(), "and the state agrees");
-
-    out = ApplyFeedback(st, LossyLink(10), kT0 + 2'000'000, r.Hooks());
-    Check(!out.fecToggled, "more loss is not another edge");
-    Check(st.wantFec.load(), "and it stays on");
 }
 
 void TestQualityStepIsAppliedThroughTheHook() {

--- a/core/tests/transport/LossGoodputTests.cpp
+++ b/core/tests/transport/LossGoodputTests.cpp
@@ -1,0 +1,136 @@
+#include "Tests.h"
+#include "support/TestSupport.h"
+
+#include "deskhub/transport/Packetizer.h"
+#include "deskhub/transport/Reassembler.h"
+
+#include <cstdio>
+#include <map>
+#include <vector>
+
+using namespace deskhub;
+
+namespace {
+
+constexpr uint64_t kFrameIntervalUs = 16'667;
+constexpr uint64_t kOneWayDelayUs = 20'000;
+constexpr uint64_t kKeyframeLatencyUs = 120'000;
+constexpr size_t kFrameCount = 400;
+constexpr size_t kTailBurstPackets = 6;
+constexpr uint32_t kFramesBetweenLosses = 50;
+constexpr size_t kDeltaFramePackets = 8;
+constexpr size_t kKeyframePackets = 40;
+constexpr uint64_t kAcceptableStallUs = 4 * kFrameIntervalUs;
+constexpr double kRequiredGoodputPct = 99.0;
+
+struct LinkOutcome {
+    size_t framesFullyReceived = 0;
+    size_t framesDelivered = 0;
+    size_t lossEvents = 0;
+    uint64_t longestStallUs = 0;
+
+    double goodputPct() const {
+        return framesFullyReceived
+                   ? 100.0 * double(framesDelivered) / double(framesFullyReceived)
+                   : 0.0;
+    }
+};
+
+std::vector<uint8_t> FramePayload(size_t packets) {
+    std::vector<uint8_t> nal(packets * kMaxVideoPayload - 64);
+    for (auto& b : nal) b = uint8_t(Rnd());
+    return nal;
+}
+
+bool TailIsDropped(uint32_t frameId, bool idr) {
+    return !idr && frameId != 0 && frameId % kFramesBetweenLosses == 0;
+}
+
+LinkOutcome RunTailLossLink() {
+    Packetizer host;
+    host.SetSessionId(7);
+    Reassembler viewer(kFrameIntervalUs);
+    viewer.SetRttUs(2 * kOneWayDelayUs);
+
+    LinkOutcome outcome;
+    std::multimap<uint64_t, Datagram> inFlight;
+    uint64_t simNowUs = 0;
+    uint64_t keyframeDueAtUs = 0;
+    bool keyframePending = false;
+    uint64_t lastDeliveryUs = 0;
+    bool everDelivered = false;
+
+    viewer.onReferenceLost = [&](uint32_t) {
+        ++outcome.lossEvents;
+        if (keyframePending) return;
+        keyframePending = true;
+        keyframeDueAtUs = simNowUs + kOneWayDelayUs + kKeyframeLatencyUs;
+    };
+
+    for (uint32_t frameId = 0; frameId < kFrameCount; ++frameId) {
+        const uint64_t sendUs = uint64_t(frameId) * kFrameIntervalUs;
+        simNowUs = sendUs;
+
+        const bool idr = frameId == 0 || (keyframePending && sendUs >= keyframeDueAtUs);
+        if (idr) keyframePending = false;
+
+        const std::vector<uint8_t> nal =
+            FramePayload(idr ? kKeyframePackets : kDeltaFramePackets);
+        std::vector<Datagram> wire;
+        host.SendFrame(nal, frameId, sendUs, idr, [&](std::span<const uint8_t> d) {
+            wire.emplace_back(d.begin(), d.end());
+        });
+
+        if (TailIsDropped(frameId, idr))
+            wire.resize(wire.size() > kTailBurstPackets ? wire.size() - kTailBurstPackets : 0);
+        else
+            ++outcome.framesFullyReceived;
+
+        for (const Datagram& d : wire) inFlight.emplace(sendUs + kOneWayDelayUs, d);
+
+        simNowUs = sendUs + kFrameIntervalUs;
+        while (!inFlight.empty() && inFlight.begin()->first <= simNowUs) {
+            const auto it = inFlight.begin();
+            Feed(viewer, it->second, it->first);
+            inFlight.erase(it);
+        }
+
+        while (auto out = viewer.PopReady(simNowUs)) {
+            ++outcome.framesDelivered;
+            const uint64_t sinceLastUs = simNowUs - lastDeliveryUs;
+            if (everDelivered && sinceLastUs > outcome.longestStallUs)
+                outcome.longestStallUs = sinceLastUs;
+            lastDeliveryUs = simNowUs;
+            everDelivered = true;
+        }
+    }
+    return outcome;
+}
+
+void TestTailLossCostsOnlyTheFramesItTookOut() {
+    std::printf("[goodput] tail loss must cost only the frames it actually took out...\n");
+    const LinkOutcome outcome = RunTailLossLink();
+
+    Check(outcome.lossEvents >= kFrameCount / kFramesBetweenLosses - 1,
+        "the simulated link really does lose frames, or the gate is measuring nothing");
+    Check(outcome.framesFullyReceived > kFrameCount / 2,
+        "and it still delivers most frames intact, or the gate is measuring a dead link");
+
+    if (outcome.goodputPct() < kRequiredGoodputPct)
+        std::printf("[goodput]   %zu of %zu intact frames reached the decoder (%.1f%%)\n",
+            outcome.framesDelivered, outcome.framesFullyReceived, outcome.goodputPct());
+    Check(outcome.goodputPct() >= kRequiredGoodputPct,
+        "every frame whose packets all arrived reaches the decoder, not only those after an IDR");
+
+    if (outcome.longestStallUs > kAcceptableStallUs)
+        std::printf("[goodput]   longest gap between delivered frames: %llu ms\n",
+            (unsigned long long)(outcome.longestStallUs / 1000));
+    Check(outcome.longestStallUs <= kAcceptableStallUs,
+        "and no gap long enough to read as a frozen picture");
+}
+
+}
+
+void RunLossGoodputTests() {
+    TestTailLossCostsOnlyTheFramesItTookOut();
+}

--- a/core/tests/transport/ReassemblerTests.cpp
+++ b/core/tests/transport/ReassemblerTests.cpp
@@ -62,10 +62,12 @@ void TestReorder() {
 }
 
 void TestDropPacket() {
-    std::printf("[reasm] drop 1 packet -> drop frame, loss event, swallow until IDR...\n");
+    std::printf("[reasm] drop 1 packet -> drop that frame, keep decoding, report the bad ref...\n");
     Packetizer pk;
     pk.SetSessionId(42);
     Reassembler ra(16'667);
+    std::vector<uint32_t> invalidated;
+    ra.onReferenceLost = [&](uint32_t frameId) { invalidated.push_back(frameId); };
     std::vector<TestFrame> frames;
     for (uint32_t i = 0; i < 20; ++i) {
         TestFrame f{i, (i % 10) == 0, {}};
@@ -85,12 +87,49 @@ void TestDropPacket() {
         now += 16'667;
     }
     std::vector<uint32_t> want;
-    for (uint32_t i = 0; i < 5; ++i) want.push_back(i);
-    for (uint32_t i = 10; i < 20; ++i) want.push_back(i);
-    Check(got == want, "frame sequence after packet loss matches policy");
+    for (uint32_t i = 0; i < 20; ++i)
+        if (i != 5) want.push_back(i);
+    Check(got == want, "only the incomplete frame is lost, the rest still reach the decoder");
     Check(sawLoss, "loss event occurred after dropping frame");
     Check(ra.stats().framesDropped == 1 && ra.stats().packetsLost == 1, "drop/lost stats");
-    Check(ra.stats().framesSkipped == 4, "4 non-IDR frames swallowed");
+    Check(ra.stats().framesSkipped == 0, "no complete frame is thrown away after a loss");
+    Check(invalidated == std::vector<uint32_t>{5}, "the dropped frame is reported as a bad ref");
+}
+
+void TestStallTimeoutFollowsRtt() {
+    std::printf("[reasm] stall window stretches to cover a retransmit round trip...\n");
+    const uint64_t frameInterval = 16'667;
+    const uint64_t pacedWindow = 2 * frameInterval;
+    const uint64_t rttUs = 100'000;
+
+    auto framesDroppedAfter = [&](uint64_t rtt, uint64_t waitUs) {
+        Packetizer pk;
+        pk.SetSessionId(42);
+        Reassembler ra(frameInterval);
+        ra.SetRttUs(rtt);
+        const TestFrame idr = MakeIdrFrame(0, 4);
+        uint64_t now = 1'000'000;
+        for (const auto& d : Packetize(pk, idr, now)) Feed(ra, d, now);
+        Check(ra.PopReady(now).has_value(), "IDR opens the stream");
+
+        TestFrame next{1, false, {}};
+        next.nal.resize(4 * kMaxVideoPayload - 50);
+        for (auto& b : next.nal) b = uint8_t(Rnd());
+        now += frameInterval;
+        auto pkts = Packetize(pk, next, now);
+        pkts.pop_back();
+        for (const auto& d : pkts) Feed(ra, d, now);
+
+        ra.PopReady(now + waitUs);
+        return ra.stats().framesDropped;
+    };
+
+    const uint64_t beyondPaced = pacedWindow + frameInterval;
+    Check(framesDroppedAfter(0, beyondPaced) == 1,
+        "with no RTT measured the paced window still applies");
+    Check(framesDroppedAfter(rttUs, beyondPaced) == 0,
+        "a long RTT holds the frame long enough for a retransmit");
+    Check(framesDroppedAfter(rttUs, rttUs * 2) == 1, "the stretched window is still bounded");
 }
 
 void TestDuplicates() {
@@ -136,7 +175,7 @@ void TestJoinMidStream() {
 }
 
 void TestHeadTimeout() {
-    std::printf("[reasm] frame missing a piece past 2 frame intervals -> drop on timeout...\n");
+    std::printf("[reasm] frame missing a piece past the stall window -> drop only that frame...\n");
     Packetizer pk;
     pk.SetSessionId(42);
     Reassembler ra(16'667);
@@ -159,12 +198,14 @@ void TestHeadTimeout() {
     Check(!ra.PopReady(now).has_value(), "not dropped yet while still within deadline");
 
     now += 40'000;
-    Check(!ra.PopReady(now).has_value(), "frame 2 (non-IDR after loss) not emitted");
+    out = ra.PopReady(now);
+    Check(out && out->frameId == 2, "frame 2 follows the gap straight through to the decoder");
+    Check(ra.stats().framesDropped == 1, "only the incomplete frame counts as dropped");
     Check(ra.TakeLossEvent(), "loss event after timeout");
 
     for (const auto& d : Packetize(pk, frames[3], now)) Feed(ra, d, now);
     out = ra.PopReady(now);
-    Check(out && out->frameId == 3, "recovered via IDR after loss");
+    Check(out && out->frameId == 3, "the keyframe that repairs the reference still arrives");
 }
 
 void TestNackPlanning() {
@@ -477,6 +518,7 @@ void RunReassemblerTests() {
     TestInOrder();
     TestReorder();
     TestDropPacket();
+    TestStallTimeoutFollowsRtt();
     TestDuplicates();
     TestJoinMidStream();
     TestHeadTimeout();

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -146,7 +146,9 @@ HostEngine (one per app, owns SessionTransport)
   encode feeds every viewer of that source.
 - The feedback loop: viewers send `Feedback` (loss/RTT) once a second; the host's
   `BitrateController` (AIMD) and `QualityLadder` adjust encoder bitrate, resolution
-  and fps; FEC toggles on loss. quiche's CUBIC congestion control sits underneath the
+  and fps; FEC is armed from the first frame and only stood down after a long clean run,
+  because the loss it protects against shows up before the first report does. quiche's
+  CUBIC congestion control sits underneath the
   datagram path; the two act in series — quiche bounds what leaves the machine, the
   app adapts the encoder to the loss that results.
 - Input: "host wins" — `LocalInputMonitor` pauses remote input while the person at
@@ -271,6 +273,51 @@ under-load integration numbers from the pull-request build, and the core coverag
 line.
 
 ## 9. Decisions worth remembering
+
+- **The send pacer must stay well above the encoder's own output rate**: `Pacer::Gate`
+  sleeps on whichever thread `SendEncodedFrame` runs on, and on Android that is
+  MediaCodec's drain loop — the same loop that must call `releaseOutputBuffer` before the
+  encoder can hand over the next frame. Pacing therefore sets the drain rate, not just
+  the wire rate, while the VirtualDisplay keeps pushing new frames in at screen rate.
+  Narrowing `kPacingRateMultiple` from 2 to 1.2 to smooth send bursts was measured on a
+  Pixel 4: burst per frame went from 20 ms to 63 ms median, and the encoder backlog grew
+  without bound — `enc_lat_ms` climbed past 46 s in 100 s, and the viewer sat 4.6 s
+  behind. At 2 the same run held `enc_lat_ms` at 0. The headroom is not slack to reclaim;
+  it is what keeps the encode pipeline draining faster than it fills. Attack send bursts
+  with socket buffers or by moving pacing off the drain thread, never by tightening this
+  number.
+
+- **The perf suite gates on cost, so a second gate has to watch outcome**: `core_perf`
+  measures allocations per packet and how time scales with input, and every one of its
+  reassembler workloads passed while a single lost packet was costing 22 % of the intact
+  frames on a real link. It could not have caught it: discarding good video is *cheaper*
+  than decoding it, so the broken policy scored better on every number the suite watches.
+  `LossGoodputTests` is the companion that fails when the code does less work than it
+  should — a simulated tail-loss link with a real round trip, gating on the fraction of
+  frames whose packets all arrived that actually reach the decoder, and on the longest
+  gap between two delivered frames. Both are machine-independent, so they hold on a
+  laptop, a CI runner and a phone alike. Reach for a goodput gate whenever a policy can
+  "succeed" by throwing work away.
+
+- **A lost packet costs one frame, not the whole picture until the next keyframe**: the
+  reassembler used to arm `waitingForIdr_` on every loss, so a single missing packet
+  threw away every *complete* frame that followed until a fresh IDR arrived. Measured on
+  a phone host over Wi-Fi, that turned 64 genuinely incomplete frames into 381 discarded
+  ones — 6.4 MB of decodable video binned, and a picture frozen for a median of 146 ms
+  and up to 1.4 s at a time. Now only the incomplete frame is dropped; the frames behind
+  it go straight to the decoder, which conceals the missing reference while
+  `InvalidateRef` names the bad frame to the host and the keyframe request repairs it.
+  Brief macroblock artifacts are the deliberate price of not freezing. `waitingForIdr_`
+  survives for the one case it was right about: a viewer joining mid-stream has no
+  reference at all and must wait for the first IDR.
+
+- **The stall window has to outlast a retransmit, or NACK is decoration**: a frame used
+  to be given two frame intervals (33 ms at 60 fps) before it was declared lost, while
+  the measured RTT on the same link was 24-49 ms. The NACK went out and its answer
+  arrived after the frame had already been binned — visible as `late_ms_avg=24` with 87
+  packets per second landing on frames that no longer existed. `StallTimeoutUs` now takes
+  the larger of the paced window and one-and-a-half round trips, still capped by the hard
+  timeout, so retransmission is worth asking for on exactly the links that need it.
 
 - **The performance suite gates on allocations and shape, not on milliseconds**: the
   three test suites build debug, and CI runs them again under ASan, TSan and coverage,

--- a/docs/ARCHITECTURE.vi.md
+++ b/docs/ARCHITECTURE.vi.md
@@ -147,7 +147,9 @@ HostEngine (một cho cả app, sở hữu SessionTransport)
   lần mã hoá nuôi mọi viewer của nguồn đó.
 - Vòng phản hồi: viewer gửi `Feedback` (loss/RTT) mỗi giây; `BitrateController`
   (AIMD) và `QualityLadder` của host chỉnh bitrate, độ phân giải, fps của encoder;
-  FEC bật theo loss. CUBIC của quiche nằm dưới đường datagram; hai bộ hoạt động nối
+  FEC bật sẵn từ frame đầu và chỉ hạ xuống sau một chuỗi dài không mất gói, vì loss mà
+  nó chống lại xuất hiện trước cả báo cáo đầu tiên. CUBIC của quiche nằm dưới đường
+  datagram; hai bộ hoạt động nối
   tiếp — quiche giới hạn thứ rời khỏi máy, app điều tốc encoder theo loss sinh ra.
 - Input: "host thắng" — `LocalInputMonitor` tạm dừng input từ xa khi người ngồi tại
   máy động vào chuột thật; mỗi lúc một viewer điều khiển.
@@ -264,6 +266,48 @@ lệch chỉ là cảnh báo, không bao giờ đánh trượt), số đo tích 
 pull request, và dòng coverage của `core/`.
 
 ## 9. Các quyết định đáng nhớ
+
+- **Bộ điều tốc gửi phải luôn cao hơn hẳn tốc độ ra của chính encoder**: `Pacer::Gate`
+  ngủ ngay trên thread mà `SendEncodedFrame` đang chạy, và trên Android đó là vòng drain
+  của MediaCodec — đúng vòng phải gọi `releaseOutputBuffer` trước khi encoder giao được
+  frame kế tiếp. Vì vậy điều tốc quyết định tốc độ drain, không chỉ tốc độ trên dây, trong
+  khi VirtualDisplay vẫn bơm frame mới vào theo nhịp màn hình. Việc siết
+  `kPacingRateMultiple` từ 2 xuống 1.2 để làm mượt burst đã được đo trên Pixel 4: thời
+  gian gửi mỗi frame tăng từ 20 ms lên 63 ms trung vị, và hàng đợi encoder phình vô hạn —
+  `enc_lat_ms` vượt 46 s chỉ sau 100 s, viewer tụt lại 4.6 s. Với giá trị 2, cùng kịch
+  bản giữ `enc_lat_ms` ở 0. Khoảng dư đó không phải phần thừa để thu hồi; nó là thứ giữ
+  cho đường mã hoá rút nhanh hơn tốc độ nạp vào. Muốn giảm burst thì dùng bộ đệm socket
+  hoặc tách điều tốc khỏi thread drain, tuyệt đối không siết con số này.
+
+- **Bộ perf gate trên chi phí, nên cần một gate thứ hai canh kết quả**: `core_perf` đo
+  số lần cấp phát trên mỗi packet và cách thời gian giãn theo input, và mọi workload
+  reassembler của nó đều pass trong khi một packet mất làm mất 22 % số frame nguyên vẹn
+  trên đường truyền thật. Nó không thể bắt được: vứt video tốt còn *rẻ hơn* giải mã nó,
+  nên chính sách hỏng lại ghi điểm cao hơn ở mọi con số bộ suite theo dõi.
+  `LossGoodputTests` là bộ đi kèm, fail khi code làm ít việc hơn mức đáng phải làm — một
+  đường truyền mất gói đuôi mô phỏng với vòng truyền thật, gate trên tỉ lệ frame nhận đủ
+  packet mà thực sự tới được decoder, và trên khoảng cách dài nhất giữa hai frame được
+  giao. Cả hai đều độc lập với máy, nên đúng như nhau trên laptop, CI runner hay điện
+  thoại. Hãy nghĩ tới goodput gate mỗi khi một chính sách có thể "thành công" bằng cách
+  vứt bớt việc.
+
+- **Mất một packet chỉ tốn một frame, không phải cả khung hình tới keyframe kế tiếp**:
+  trước đây bộ ghép lại bật `waitingForIdr_` với mọi lần mất, nên chỉ một packet thiếu
+  là vứt sạch mọi frame *nguyên vẹn* phía sau cho tới khi có IDR mới. Đo trên host điện
+  thoại qua Wi-Fi, 64 frame thực sự thiếu đã kéo theo 381 frame bị vứt — 6.4 MB video
+  giải mã được bị bỏ, hình đứng trung vị 146 ms và có lúc tới 1.4 s. Giờ chỉ frame thiếu
+  bị bỏ; các frame sau đi thẳng tới decoder, nơi che khuyết tham chiếu đã mất, trong khi
+  `InvalidateRef` báo cho host frame nào hỏng và yêu cầu keyframe sửa lại. Vài vệt
+  macroblock ngắn là cái giá cố ý trả để không đứng hình. `waitingForIdr_` giữ lại đúng
+  trường hợp nó đúng: viewer vào giữa luồng chưa có tham chiếu nào nên phải đợi IDR đầu.
+
+- **Cửa sổ chờ phải dài hơn một vòng truyền lại, nếu không NACK chỉ là trang trí**:
+  trước đây một frame chỉ được cho hai chu kỳ khung hình (33 ms ở 60 fps) trước khi bị
+  coi là mất, trong khi RTT đo được trên cùng đường là 24-49 ms. NACK gửi đi và câu trả
+  lời về sau khi frame đã bị vứt — thấy rõ qua `late_ms_avg=24` với 87 packet mỗi giây
+  rơi vào những frame không còn tồn tại. `StallTimeoutUs` giờ lấy giá trị lớn hơn giữa
+  cửa sổ theo nhịp khung hình và một vòng rưỡi RTT, vẫn bị chặn bởi hard timeout, nên
+  việc yêu cầu truyền lại chỉ đáng giá trên đúng những đường cần nó.
 
 - **`FileHost` không bao giờ gửi khi đang giữ khoá của chính nó**: vòng lặp phục vụ QUIC
   chạy `QuicEndpoint::Poll` dưới `SessionTransport::sendMutex_`, và một kết nối đóng lại ở

--- a/platform/src/host/HostNetLoop.cpp
+++ b/platform/src/host/HostNetLoop.cpp
@@ -100,6 +100,8 @@ deskhub::ScreenHostCallbacks MakeScreenHostCallbacks(deskhub::SourcePipelineStat
 
     cb.onKeyframeRequest = [p] { p->forceIdr.store(true); };
 
+    cb.onInvalidateRef = [p](uint32_t) { p->forceIdr.store(true); };
+
     cb.onNack = [p, shared](uint32_t frameId, std::span<const uint16_t> indices) {
         if (!shared->sendToRequester) return;
         deskhub::RespondToNack(*p, frameId, indices, shared->sendToRequester);

--- a/platform/src/net/UdpSocketPosix.cpp
+++ b/platform/src/net/UdpSocketPosix.cpp
@@ -47,6 +47,9 @@ bool UdpSocket::Open(uint16_t localPort, const std::string& bindIp) {
     int rcvbuf = 4 * 1024 * 1024;
     setsockopt(s, SOL_SOCKET, SO_RCVBUF, &rcvbuf, sizeof(rcvbuf));
 
+    int sndbuf = 4 * 1024 * 1024;
+    setsockopt(s, SOL_SOCKET, SO_SNDBUF, &sndbuf, sizeof(sndbuf));
+
     sockaddr_in local{};
     local.sin_family = AF_INET;
     local.sin_addr.s_addr = htonl(INADDR_ANY);

--- a/platform/src/net/UdpSocketWin.cpp
+++ b/platform/src/net/UdpSocketWin.cpp
@@ -68,6 +68,9 @@ bool UdpSocket::Open(uint16_t localPort, const std::string& bindIp) {
     int rcvbuf = 4 * 1024 * 1024;
     setsockopt(s, SOL_SOCKET, SO_RCVBUF, (const char*)&rcvbuf, sizeof(rcvbuf));
 
+    int sndbuf = 4 * 1024 * 1024;
+    setsockopt(s, SOL_SOCKET, SO_SNDBUF, (const char*)&sndbuf, sizeof(sndbuf));
+
     sockaddr_in local{};
     local.sin_family = AF_INET;
     local.sin_addr.s_addr = htonl(INADDR_ANY);

--- a/platform/tests/session/ScreenHostCallbackTests.cpp
+++ b/platform/tests/session/ScreenHostCallbackTests.cpp
@@ -280,7 +280,7 @@ void TestFeedbackDrivesTheEncoder() {
     Check(st->rate.bitrateBps() < kStartBps,
         "a lossy link pulls the bitrate down instead of insisting on the original");
     Check(rec.bitrateCalls >= 1, "and the encoder is told about it");
-    Check(st->wantFec.load(), "20% loss turns FEC on");
+    Check(st->wantFec.load(), "20% loss keeps FEC on");
 }
 
 void TestAHealthyLinkIsLeftAlone() {
@@ -297,7 +297,7 @@ void TestAHealthyLinkIsLeftAlone() {
     cb.onFeedback(fb);
 
     Check(st->rate.bitrateBps() == kStartBps, "no loss, no reason to change the bitrate");
-    Check(!st->wantFec.load(), "and no reason to pay for FEC");
+    Check(st->wantFec.load(), "and one clean second is not yet proof FEC can be dropped");
     Check(st->uiRttMs.load() == 5, "the UI still learns the measured round trip");
     Check(st->haveFeedback.load(), "and knows the numbers are real, not placeholders");
 }


### PR DESCRIPTION
## The problem

Deskhub freezes when a phone hosts and a desktop watches. The cause is not encode
or decode cost — every CPU number in the logs was healthy (`enc_ms_max=2`,
`dec_ms=0.7/2`, `present_ms=1`) while end-to-end latency hit 633 ms.

The reassembler armed `waitingForIdr_` on **every** loss, so one missing packet
threw away every *complete* frame that followed until a fresh IDR arrived.

Measured across the log archive, one 142-second phone session:

| | |
| --- | --- |
| Frames dropped as `pre_idr`, all with `miss=0/N` — nothing missing | **381** |
| Genuinely incomplete frames that triggered them | 64 |
| Decodable video binned | **6.4 MB** |
| Time frozen | **24.6 s of 142 s (17%)** |
| IDR waits | median 146 ms, p90 419 ms, max 1361 ms |

Loss was 66% tail-position on phone hosts (61 of 92) versus 18% on desktop hosts —
the phone's Wi-Fi uplink drops the end of each frame burst, and that is the worst
case for a reassembler that reacts by discarding everything behind it.

## What changed

- **Only the incomplete frame is dropped.** Frames behind it reach the decoder,
  which conceals the missing reference. `waitingForIdr_` survives for the one case
  it was right about: a viewer joining mid-stream.
- **`InvalidateRef` is no longer dead code.** The message existed and the host
  parsed it, but nothing sent it and nothing wired `onInvalidateRef`. Both ends
  are connected now.
- **The stall window stretches to cover a retransmit.** It was a fixed two frame
  intervals (33 ms at 60 fps) while measured RTT was 24–49 ms, so NACK answers
  arrived after the frame was already binned — visible as 87 packets/s landing on
  frames that no longer existed. It now takes the larger of the paced window and
  one and a half round trips.
- **FEC is armed from the first frame** rather than a second after loss is first
  reported at 1 Hz.
- `SO_SNDBUF` is set alongside the existing `SO_RCVBUF`.
- Android applies an fps ladder step in place instead of rebuilding MediaCodec.
- The Windows viewer takes `ALLOW_TEARING` so `Present(0, …)` really does not wait.

## Verified on hardware

Pixel 4 host over Wi-Fi → Windows client over Ethernet, 104 s of continuous motion:

| | Before | After |
| --- | --- | --- |
| Loss events | 4 (in 36 s) | **29** (in 104 s) |
| Intact frames discarded | 19 | **0** |
| e2e | median 25 ms | median **20 ms**, p99 56 ms |
| fps | — | median **60**, p10 56 |

Seven times more loss, and nothing thrown away.

## Why the existing suites missed it

`core_perf` gates on allocations per packet and how time scales with input.
Discarding good video is *cheaper* than decoding it, so the broken policy scored
better on every number it watches.

`LagUnderCrossLoadTests` does measure a stall gap, but `kWorstGapMs = 1500` — and
the worst freeze in the entire log archive was 1361 ms. Nothing ever reached the
threshold. It also runs on loopback, where there is no loss to trigger the path.

Worse, the behaviour was not uncovered: `TestDropPacket` and `TestHeadTimeout`
asserted `"4 non-IDR frames swallowed"` and `"frame 2 (non-IDR after loss) not
emitted"` as the expected result. Both are rewritten here.

`LossGoodputTests` is the new gate — a simulated tail-loss link with a real round
trip, gating on the fraction of frames whose packets all arrived that actually
reach the decoder, and on the longest gap between two delivered frames. Verified
in both directions: **78.4% goodput / 233 ms gap on the old code (fails), 100% and
under four frame intervals on this one.**

## Also worth knowing

Two changes were tried and reverted rather than shipped:

- **Narrowing the send pacer from 2× to 1.2×** to smooth bursts. `Pacer::Gate`
  sleeps on MediaCodec's drain loop, so pacing sets the *drain* rate, not just the
  wire rate. A/B on the Pixel 4: `enc_lat_ms` grew past 46 s in 100 s and the
  viewer sat 4.6 s behind, versus flat at 0 with the original 2×. Documented in
  `ARCHITECTURE.md` §9 so nobody reads that headroom as slack again.
- **Reordering the Media Foundation low-latency call.** `AVLowLatencyMode
  rejected: 0x80070057` persisted, so it achieved nothing. The `MF_LOW_LATENCY`
  attribute already set on the MFT is the path that works; the warning is
  cosmetic.

## Not addressed

FEC parity strength. Single XOR per group recovers exactly one missing packet per
group, and the real bursts are 23–78 packets. Fixing it means carrying the group
count on the wire, which is too invasive to bundle here.

## Checks

- `make test` — pass, including the new gate
- `make lint` — clean
- `make lint-tidy` — 7 findings, all pre-existing in files this branch does not
  touch (`DiscoveryFfi.cpp`, `LocalInputWin.cpp`, `DisplayEnumWin.cpp`,
  `PtyWin.cpp`, `LogFile.h`)
- `make test-all` — still running locally when this was opened; CI is the check
  that counts
