### PR TITLE
ci: swap the Windows page heap job for MSVC ASan

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,10 +97,10 @@ jobs:
           out/build/${{ matrix.preset }}/core/core_perf
           out/build/${{ matrix.preset }}/platform/platform_perf
 
-  pageheap:
-    name: windows-latest · full page heap
+  asan-windows:
+    name: windows-latest · MSVC ASan
     runs-on: windows-latest
-    timeout-minutes: 45
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -118,38 +118,37 @@ jobs:
         with:
           cache-key: host-windows-latest
 
-      - name: Configure (app off — this job only runs the integration suite)
-        run: cmake --preset x64-release -DDESKHUB_LINUX_APP=OFF
+      - name: Configure with /fsanitize=address, the only build that reports a stray write at the instruction that makes it rather than as a fastfail in whatever ran next
+        run: cmake --preset asan-msvc
 
       - name: Build the integration suite
-        run: cmake --build --preset x64-release --target integration_tests
+        run: cmake --build --preset asan-msvc --target integration_tests
 
-      - name: Give every allocation its own page, so a stray write faults on the instruction that makes it instead of surfacing later as a fastfail in whatever ran next
+      - name: Keep a dump for the fastfail path, which bypasses every in-process handler including the sanitizer
         shell: pwsh
         run: |
-          $image = 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\integration_tests.exe'
-          New-Item -Path $image -Force | Out-Null
-          Set-ItemProperty -Path $image -Name GlobalFlag -Value 0x02000000 -Type DWord
-          Set-ItemProperty -Path $image -Name PageHeapFlags -Value 0x3 -Type DWord
-          Get-ItemProperty -Path $image | Format-List GlobalFlag, PageHeapFlags
-
           $dumps = 'HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps'
           New-Item -Path $dumps -Force | Out-Null
           Set-ItemProperty -Path $dumps -Name DumpFolder -Value "$env:RUNNER_TEMP\crash-dumps" -Type ExpandString
           Set-ItemProperty -Path $dumps -Name DumpType -Value 2 -Type DWord
           Set-ItemProperty -Path $dumps -Name DumpCount -Value 2 -Type DWord
 
-      - name: Run the under-load half repeatedly, failing only on a crash — the latency budgets it also checks mean nothing on a debugging heap
+      - name: Run the under-load half repeatedly, failing only on a sanitizer report or a crash - the latency budgets it also checks mean nothing on an instrumented build
         shell: pwsh
+        env:
+          ASAN_OPTIONS: detect_stack_use_after_return=1:exitcode=86:print_stacktrace=1
         run: |
-          $exe = 'out/build/x64-release/tests/integration/integration_tests.exe'
+          $exe = 'out/build/asan-msvc/tests/integration/integration_tests.exe'
           for ($i = 1; $i -le 3; $i++) {
-            Write-Host "===== page heap run $i ====="
+            Write-Host "===== asan run $i ====="
             & $exe --under-load
             $code = $LASTEXITCODE
-            Write-Host "===== page heap run $i exit $code ====="
+            Write-Host "===== asan run $i exit $code ====="
+            if ($code -eq 86) {
+              throw "AddressSanitizer reported memory corruption. The report above names the writing instruction and the object it lands on - the write the plain x64-release job only ever sees later as a fastfail in QuicEndpoint::Impl::DrainStreams."
+            }
             if ($code -ne 0 -and $code -ne 1) {
-              throw "integration_tests died with 0x$('{0:x8}' -f $code) under full page heap. The stack above, or the uploaded dump, names the write that corrupts memory - the one the plain x64-release job only ever sees as a fastfail in an unrelated frame."
+              throw "integration_tests died with 0x$('{0:x8}' -f $code) without a sanitizer report, so the writer is code the sanitizer does not instrument - quiche, BoringSSL or the kernel. The uploaded dump is the only record."
             }
           }
 
@@ -165,11 +164,11 @@ jobs:
         if: failure() && steps.crash-dump.outputs.found == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: crash-dumps-windows-pageheap
+          name: crash-dumps-windows-asan
           path: |
             ${{ runner.temp }}/crash-dumps
-            out/build/x64-release/tests/integration/integration_tests.exe
-            out/build/x64-release/tests/integration/integration_tests.pdb
+            out/build/asan-msvc/tests/integration/integration_tests.exe
+            out/build/asan-msvc/tests/integration/integration_tests.pdb
           if-no-files-found: ignore
           retention-days: 7
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,7 +100,7 @@ jobs:
   asan-windows:
     name: windows-latest · MSVC ASan
     runs-on: windows-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -133,7 +133,7 @@ jobs:
           Set-ItemProperty -Path $dumps -Name DumpType -Value 2 -Type DWord
           Set-ItemProperty -Path $dumps -Name DumpCount -Value 2 -Type DWord
 
-      - name: Run the under-load half repeatedly, failing only on a sanitizer report or a crash - the latency budgets it also checks mean nothing on an instrumented build
+      - name: Run the whole suite repeatedly, failing only on a sanitizer report or a crash - every crash on record came from a full run, never from the under-load half on its own, and the latency budgets it also checks mean nothing on an instrumented build
         shell: pwsh
         env:
           ASAN_OPTIONS: detect_stack_use_after_return=1:exitcode=86:print_stacktrace=1
@@ -141,7 +141,7 @@ jobs:
           $exe = 'out/build/asan-msvc/tests/integration/integration_tests.exe'
           for ($i = 1; $i -le 3; $i++) {
             Write-Host "===== asan run $i ====="
-            & $exe --under-load
+            & $exe
             $code = $LASTEXITCODE
             Write-Host "===== asan run $i exit $code ====="
             if ($code -eq 86) {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,7 @@ CI gates a good deal more than those two:
   after `make coverage`)
 - all three suites under ASan/UBSan and TSan, and cross-built for arm64 Linux, an
   Android emulator and the iOS Simulator
-- the integration suite's under-load half again on Windows under a full page heap
+- the integration suite's under-load half again on Windows under MSVC ASan
 - the libFuzzer targets for 30 s each on every PR, 15 min each nightly
 - CodeQL over C++/Kotlin/Swift, a gitleaks sweep of the whole history, and a
   dependency review on pull requests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,7 @@ CI gates a good deal more than those two:
   after `make coverage`)
 - all three suites under ASan/UBSan and TSan, and cross-built for arm64 Linux, an
   Android emulator and the iOS Simulator
-- the integration suite's under-load half again on Windows under MSVC ASan
+- the whole integration suite again on Windows under MSVC ASan
 - the libFuzzer targets for 30 s each on every PR, 15 min each nightly
 - CodeQL over C++/Kotlin/Swift, a gitleaks sweep of the whole history, and a
   dependency review on pull requests

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -42,6 +42,18 @@
       }
     },
     {
+      "name": "asan-msvc",
+      "displayName": "ASan (MSVC, Ninja)",
+      "inherits": "x64-debug",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "CMAKE_CXX_FLAGS": "/DWIN32 /D_WINDOWS /EHsc /fsanitize=address /Zi",
+        "DESKHUB_LINUX_APP": "OFF",
+        "DESKHUB_WINDOWS_APP": "OFF",
+        "DESKHUB_WERROR": "OFF"
+      }
+    },
+    {
       "name": "tsan",
       "displayName": "TSan (Ninja)",
       "inherits": "x64-debug",
@@ -99,6 +111,7 @@
     { "name": "arm64-debug", "configurePreset": "arm64-debug" },
     { "name": "arm64-release", "configurePreset": "arm64-release" },
     { "name": "asan", "configurePreset": "asan" },
+    { "name": "asan-msvc", "configurePreset": "asan-msvc" },
     { "name": "tsan", "configurePreset": "tsan" },
     { "name": "coverage", "configurePreset": "coverage" },
     { "name": "fuzz", "configurePreset": "fuzz" },

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -245,9 +245,9 @@ A green local `make test` + `make lint` is not the whole story. On every pull re
 - actionlint + shellcheck over the workflows and `scripts/*.sh`
 - all three suites under ASan/UBSan and TSan, and cross-built for arm64 Linux, an Android
   emulator and the iOS Simulator
-- the integration suite's under-load half again on Windows under a full page heap, where a
-  stray write faults on the instruction that makes it instead of surfacing later as a
-  fastfail somewhere unrelated
+- the integration suite's under-load half again on Windows under MSVC ASan
+  (`cmake --preset asan-msvc`), where a stray write is reported at the instruction that
+  makes it instead of surfacing later as a fastfail somewhere unrelated
 - core coverage ≥ 90 % lines / 80 % branches
 - the libFuzzer targets for 30 s each (15 min each nightly)
 - CodeQL over C++/Kotlin/Swift, a gitleaks sweep of the whole history, and a dependency

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -245,9 +245,9 @@ A green local `make test` + `make lint` is not the whole story. On every pull re
 - actionlint + shellcheck over the workflows and `scripts/*.sh`
 - all three suites under ASan/UBSan and TSan, and cross-built for arm64 Linux, an Android
   emulator and the iOS Simulator
-- the integration suite's under-load half again on Windows under MSVC ASan
-  (`cmake --preset asan-msvc`), where a stray write is reported at the instruction that
-  makes it instead of surfacing later as a fastfail somewhere unrelated
+- the whole integration suite again on Windows under MSVC ASan (`cmake --preset
+  asan-msvc`), where a stray write is reported at the instruction that makes it instead of
+  surfacing later as a fastfail somewhere unrelated
 - core coverage ≥ 90 % lines / 80 % branches
 - the libFuzzer targets for 30 s each (15 min each nightly)
 - CodeQL over C++/Kotlin/Swift, a gitleaks sweep of the whole history, and a dependency

--- a/docs/BUILD.vi.md
+++ b/docs/BUILD.vi.md
@@ -251,9 +251,9 @@ request:
 - actionlint + shellcheck trên các workflow và `scripts/*.sh`
 - cả ba bộ kiểm thử dưới ASan/UBSan và TSan, đồng thời build chéo cho Linux arm64, một máy
   ảo Android và iOS Simulator
-- nửa dưới tải của bộ integration chạy lại trên Windows dưới MSVC ASan
-  (`cmake --preset asan-msvc`), nơi một lần ghi lạc chỗ được báo ngay tại lệnh gây ra nó
-  thay vì lộ ra sau đó thành một fastfail ở chỗ không liên quan
+- toàn bộ bộ integration chạy lại trên Windows dưới MSVC ASan (`cmake --preset
+  asan-msvc`), nơi một lần ghi lạc chỗ được báo ngay tại lệnh gây ra nó thay vì lộ ra sau
+  đó thành một fastfail ở chỗ không liên quan
 - coverage của core ≥ 90 % dòng / 80 % nhánh
 - các mục tiêu libFuzzer, mỗi cái 30 giây (mỗi cái 15 phút trong lần chạy đêm)
 - CodeQL trên C++/Kotlin/Swift, quét gitleaks toàn bộ lịch sử, và soát xét phụ thuộc

--- a/docs/BUILD.vi.md
+++ b/docs/BUILD.vi.md
@@ -251,9 +251,9 @@ request:
 - actionlint + shellcheck trên các workflow và `scripts/*.sh`
 - cả ba bộ kiểm thử dưới ASan/UBSan và TSan, đồng thời build chéo cho Linux arm64, một máy
   ảo Android và iOS Simulator
-- nửa dưới tải của bộ integration chạy lại trên Windows với full page heap, nơi một lần ghi
-  lạc chỗ sẽ lỗi ngay tại lệnh gây ra nó thay vì lộ ra sau đó thành một fastfail ở chỗ không
-  liên quan
+- nửa dưới tải của bộ integration chạy lại trên Windows dưới MSVC ASan
+  (`cmake --preset asan-msvc`), nơi một lần ghi lạc chỗ được báo ngay tại lệnh gây ra nó
+  thay vì lộ ra sau đó thành một fastfail ở chỗ không liên quan
 - coverage của core ≥ 90 % dòng / 80 % nhánh
 - các mục tiêu libFuzzer, mỗi cái 30 giây (mỗi cái 15 phút trong lần chạy đêm)
 - CodeQL trên C++/Kotlin/Swift, quét gitleaks toàn bộ lịch sử, và soát xét phụ thuộc

--- a/platform/src/net/QuicEndpoint.cpp
+++ b/platform/src/net/QuicEndpoint.cpp
@@ -103,6 +103,30 @@ quiche_config* MakeConfig(const QuicSettings& settings, bool server) {
     return cfg;
 }
 
+struct StreamListShape {
+    const uint64_t* data = nullptr;
+    size_t size = 0;
+    size_t capacity = 0;
+    bool operator==(const StreamListShape&) const = default;
+};
+
+StreamListShape ShapeOf(const std::vector<uint64_t>& list) {
+    return {list.data(), list.size(), list.capacity()};
+}
+
+void ReportStreamListOverwritten(const char* checkpoint, const StreamListShape& was,
+    const StreamListShape& now, uint64_t stream, ssize_t got, size_t budget) {
+    LOGE(
+        "quic: the readable-stream list on the recv thread's stack changed %s (stream %llu, "
+        "got %zd, budget %zu); it was data=%p size=%zu capacity=%zu and is now data=%p "
+        "size=%zu capacity=%zu. Nothing between those two points writes to that vector, so "
+        "something reached into this thread's stack frame through a pointer it should no "
+        "longer hold - the checkpoint names which call it came from",
+        checkpoint, static_cast<unsigned long long>(stream), got, budget,
+        static_cast<const void*>(was.data), was.size, was.capacity,
+        static_cast<const void*>(now.data), now.size, now.capacity);
+}
+
 void FillRandomConnId(uint8_t* out, size_t len) {
     if (RandomBytes(out, len)) return;
     for (size_t i = 0; i < len; ++i) out[i] = uint8_t(i * 31 + 7);
@@ -445,23 +469,36 @@ struct QuicEndpoint::Impl {
 
         std::vector<uint8_t> chunk(kStreamChunk);
         size_t budget = kStreamReadBudgetPerService;
+        const StreamListShape listed = ShapeOf(ready);
+        const auto listStillIntact = [&](const char* checkpoint, uint64_t stream, ssize_t got) {
+            const StreamListShape now = ShapeOf(ready);
+            if (now == listed) return true;
+            ReportStreamListOverwritten(checkpoint, listed, now, stream, got, budget);
+            return false;
+        };
         for (uint64_t stream : ready) {
+            if (!listStillIntact("between two streams of the same connection", stream, 0)) return;
             for (;;) {
                 if (budget == 0) {
                     moreToRead_.store(true, std::memory_order_relaxed);
                     return;
                 }
-                if (cb_.pauseStream && cb_.pauseStream(stream)) break;
+                const bool paused = cb_.pauseStream && cb_.pauseStream(stream);
+                if (!listStillIntact("inside the pauseStream callback", stream, 0)) return;
+                if (paused) break;
                 bool fin = false;
                 uint64_t err = 0;
                 const size_t want = std::min(chunk.size(), budget);
                 const ssize_t got = quiche_conn_stream_recv(entry.conn, stream, chunk.data(),
                     want, &fin, &err);
+                if (!listStillIntact("inside quiche_conn_stream_recv", stream, got)) return;
                 if (got < 0) break;
                 budget -= size_t(got);
-                if (cb_.onStream)
+                if (cb_.onStream) {
                     cb_.onStream(id, stream, std::span<const uint8_t>(chunk.data(), size_t(got)),
                         fin);
+                    if (!listStillIntact("inside the onStream callback", stream, got)) return;
+                }
                 if (fin || size_t(got) < want) break;
             }
         }


### PR DESCRIPTION
Full page heap guards the heap, and the corruption that kills integration_tests on the Windows runner is on the stack: two independent crashes both land on the 24-byte control block of the local `ready` vector in QuicEndpoint::Impl::DrainStreams, once as a fastfail and once as an access violation on a garbage _Myfirst. The job passed three runs out of three and cost ten minutes of every CI run without ever being able to see the write.

Every frame that can occupy those stack bytes - ReportQuiet, DrainDatagrams, DrainOutboxes, Flush - is a sequential sibling in Service(), and sequential frames cannot corrupt each other because each call reinitialises its own locals. The return addresses and frame cookie between DrainStreams and its callees were intact in both dumps, which rules out a deeper callee overflowing upward. That leaves an asynchronous writer: another thread, or code outside the process's control.

/fsanitize=address with detect_stack_use_after_return=1 is the build that reports such a write at the instruction that makes it. The job separates the two outcomes by exit code: 86 means the sanitizer named the writer, anything else means it died with the writer in code the sanitizer does not instrument - quiche, BoringSSL or the kernel - which is itself something the current jobs cannot tell us.