### PR TITLE
Fix silent transfer data loss, harden the QUIC drain loop, add a Windows ASan job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -167,6 +167,52 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+  asan-windows:
+    name: windows-latest · asan
+    runs-on: windows-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: recursive
+
+      - name: Setup MSVC environment
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+        with:
+          arch: x64
+
+      - name: Install Ninja
+        run: choco install ninja nasm -y
+
+      - uses: ./.github/actions/third-party
+        with:
+          cache-key: host-windows-latest
+
+      - name: Configure (app off - this job only runs the integration suite)
+        run: cmake --preset asan-msvc -DDESKHUB_LINUX_APP=OFF
+
+      - name: Build the integration suite
+        run: cmake --build --preset asan-msvc --target integration_tests
+
+      - name: Run the suite under AddressSanitizer, the only Windows build that can name the write itself rather than the frame it landed in
+        shell: pwsh
+        env:
+          ASAN_OPTIONS: detect_stack_use_after_return=1:exitcode=42
+        run: |
+          $exe = 'out/build/asan-msvc/tests/integration/integration_tests.exe'
+          for ($i = 1; $i -le 3; $i++) {
+            Write-Host "===== asan run $i ====="
+            & $exe
+            $code = $LASTEXITCODE
+            Write-Host "===== asan run $i exit $code ====="
+            if ($code -eq 42) {
+              throw "AddressSanitizer reported a bad access. The report above names the file and line of the write - that is what the x64-release crash dump cannot give, so start there."
+            }
+            if ($code -ne 0 -and $code -ne 1) {
+              throw "integration_tests died with 0x$('{0:x8}' -f $code) under ASan without an ASan report, so the corruption is one ASan does not instrument."
+            }
+          }
+
   perf-compare:
     name: perf · pull request vs base
     if: github.event_name == 'pull_request'

--- a/core/include/deskhub/session/host/FileReceiver.h
+++ b/core/include/deskhub/session/host/FileReceiver.h
@@ -29,7 +29,7 @@ struct FileReceiverCallbacks {
     std::function<std::string(uint16_t fileIndex, const std::string& safeName, uint64_t size)>
         open;
     std::function<bool(uint16_t fileIndex, std::span<const uint8_t> data)> write;
-    std::function<void(uint16_t fileIndex, bool keep)> close;
+    std::function<bool(uint16_t fileIndex, bool keep)> close;
     std::function<void(const TransferProgress&)> onProgress;
     std::function<void(std::string_view auditLine)> onAudit;
 };
@@ -77,7 +77,7 @@ private:
 
     TransferReason Admit(const FileOffer& offer, std::vector<std::string>& safeNames) const;
     bool OpenCurrent();
-    void CloseCurrent(bool keep);
+    bool CloseCurrent(bool keep);
     void Refuse(uint32_t batchId, TransferReason reason);
     void Abort(TransferReason reason, bool tellPeer);
     void Ack(TransferReason reason);

--- a/core/perf/TransferPerf.cpp
+++ b/core/perf/TransferPerf.cpp
@@ -85,7 +85,7 @@ struct TransferRig {
                   Consume(data.size());
                   return true;
               },
-              [](uint16_t, bool) {}, {}, {}}) {
+              [](uint16_t, bool) { return true; }, {}, {}}) {
         FillRandom(source);
         receiver.SetAccepting(true);
     }

--- a/core/src/session/host/FileReceiver.cpp
+++ b/core/src/session/host/FileReceiver.cpp
@@ -119,7 +119,12 @@ void FileReceiver::OnDone(std::span<const uint8_t> payload) {
         return;
     }
 
-    CloseCurrent(true);
+    if (!CloseCurrent(true)) {
+        Audit("write_failed", stored_[index_]);
+        Ack(TransferReason::WriteFailed);
+        Abort(TransferReason::WriteFailed, false);
+        return;
+    }
     Audit("stored", stored_[index_]);
     Ack(TransferReason::Accepted);
 
@@ -153,10 +158,10 @@ bool FileReceiver::OpenCurrent() {
     return true;
 }
 
-void FileReceiver::CloseCurrent(bool keep) {
-    if (!fileOpen_) return;
+bool FileReceiver::CloseCurrent(bool keep) {
+    if (!fileOpen_) return true;
     fileOpen_ = false;
-    if (cb_.close) cb_.close(index_, keep);
+    return cb_.close ? cb_.close(index_, keep) : true;
 }
 
 void FileReceiver::Refuse(uint32_t batchId, TransferReason reason) {

--- a/core/tests/session/FileTransferTests.cpp
+++ b/core/tests/session/FileTransferTests.cpp
@@ -99,7 +99,10 @@ struct Rig {
                   return disk.Open(index, safe);
               },
               [this](uint16_t index, std::span<const uint8_t> d) { return disk.Write(index, d); },
-              [this](uint16_t index, bool keep) { disk.Close(index, keep); },
+              [this](uint16_t index, bool keep) {
+                  disk.Close(index, keep);
+                  return true;
+              },
               [this](const TransferProgress& p) { lastStored = p; },
               [this](std::string_view line) { audit.emplace_back(line); }}) {
         receiver.SetAccepting(true);

--- a/platform/include/deskhubp/system/FileStore.h
+++ b/platform/include/deskhubp/system/FileStore.h
@@ -47,7 +47,7 @@ public:
 
     std::string Open(uint16_t index, const std::string& safeName, uint64_t size);
     bool Write(uint16_t index, std::span<const uint8_t> data);
-    void Close(uint16_t index, bool keep);
+    bool Close(uint16_t index, bool keep);
     void CloseAll();
 
 private:

--- a/platform/src/host/FileHost.cpp
+++ b/platform/src/host/FileHost.cpp
@@ -139,7 +139,7 @@ FileHost::Peer* FileHost::PeerFor(const NetAddr& from) {
     hooks.write = [raw](uint16_t index, std::span<const uint8_t> data) {
         return raw->store->Write(index, data);
     };
-    hooks.close = [raw](uint16_t index, bool keep) { raw->store->Close(index, keep); };
+    hooks.close = [raw](uint16_t index, bool keep) { return raw->store->Close(index, keep); };
     hooks.onProgress = [raw](const deskhub::TransferProgress& progress) {
         raw->progress = progress;
     };

--- a/platform/src/net/QuicEndpoint.cpp
+++ b/platform/src/net/QuicEndpoint.cpp
@@ -498,6 +498,7 @@ struct QuicEndpoint::Impl {
                     cb_.onStream(id, stream, std::span<const uint8_t>(chunk.data(), size_t(got)),
                         fin);
                     if (!listStillIntact("inside the onStream callback", stream, got)) return;
+                    if (Lookup(id) != &entry) return;
                 }
                 if (fin || size_t(got) < want) break;
             }
@@ -509,8 +510,10 @@ struct QuicEndpoint::Impl {
         for (;;) {
             const ssize_t got = quiche_conn_dgram_recv(entry.conn, chunk.data(), chunk.size());
             if (got < 0) return;
-            if (cb_.onDatagram)
+            if (cb_.onDatagram) {
                 cb_.onDatagram(id, std::span<const uint8_t>(chunk.data(), size_t(got)));
+                if (Lookup(id) != &entry) return;
+            }
         }
     }
 
@@ -555,16 +558,24 @@ struct QuicEndpoint::Impl {
         moreToSend_.store(false, std::memory_order_relaxed);
         moreToRead_.store(false, std::memory_order_relaxed);
         const uint64_t nowUs = NowUs();
-        for (auto& [id, entry] : connections_) {
+        std::vector<QuicConnId> live;
+        live.reserve(connections_.size());
+        for (const auto& connection : connections_) live.push_back(connection.first);
+        for (const QuicConnId id : live) {
+            Connection* found = Lookup(id);
+            if (found == nullptr) continue;
+            Connection& entry = *found;
             if (quiche_conn_is_established(entry.conn) && !entry.announced) {
                 entry.announced = true;
                 if (entry.lastRecvUs == 0) entry.lastRecvUs = nowUs;
                 if (cb_.onConnected) cb_.onConnected(id, entry.peer);
+                if (Lookup(id) != &entry) continue;
             }
             if (entry.announced) ReportQuiet(entry, nowUs);
             if (entry.announced) {
                 DrainStreams(id, entry);
                 DrainDatagrams(id, entry);
+                if (Lookup(id) != &entry) continue;
             }
             DrainOutboxes(entry);
             Flush(entry);

--- a/platform/src/system/FileStore.cpp
+++ b/platform/src/system/FileStore.cpp
@@ -208,10 +208,10 @@ bool FileStore::Write(uint16_t index, std::span<const uint8_t> data) {
     return true;
 }
 
-void FileStore::Close(uint16_t index, bool keep) {
+bool FileStore::Close(uint16_t index, bool keep) {
     Settle();
     const auto at = open_.find(index);
-    if (at == open_.end()) return;
+    if (at == open_.end()) return !keep;
     Slot slot = std::move(at->second);
     open_.erase(at);
 
@@ -222,7 +222,7 @@ void FileStore::Close(uint16_t index, bool keep) {
     std::error_code ec;
     if (!keep || !sound) {
         std::filesystem::remove(slot.part, ec);
-        return;
+        return !keep;
     }
 
     std::filesystem::path target = slot.target;
@@ -231,16 +231,22 @@ void FileStore::Close(uint16_t index, bool keep) {
             [this](const std::string& candidate) { return Claimed(candidate); });
         if (fresh.empty()) {
             std::filesystem::remove(slot.part, ec);
-            return;
+            return false;
         }
         target = dir_ / Utf8Path(fresh);
     }
 
     std::filesystem::rename(slot.part, target, ec);
     if (ec) {
-        LOGE("transfer: could not put %s in place", Utf8Of(target).c_str());
+        LOGE(
+            "transfer: could not put %s in place, so the part file is dropped and the batch "
+            "fails; the sender is told the write failed rather than being left to believe a "
+            "file that never landed arrived",
+            Utf8Of(target).c_str());
         std::filesystem::remove(slot.part, ec);
+        return false;
     }
+    return true;
 }
 
 void FileStore::CloseAll() {


### PR DESCRIPTION
Three separate changes, one per commit. They came out of investigating the `integration_tests` fastfail (`0xc0000409`, `FAST_FAIL_STACK_COOKIE_CHECK_FAILURE`) that fails `test / windows-latest · x64-release` about one run in three.

**None of these fixes that crash.** It is still unreproduced. What follows is what the investigation actually turned up.

## `fix(transfer):` a received file could vanish while both ends reported success

Found by running the suite locally under the `asan-msvc` preset — one run in four failed with `FAIL: every byte of the file reached the host, unchanged`, and the log showed:

```
transfer: could not put ...\stream-land\bulk.bin in place
transfer stored batch=1 ... bulk.bin
transfer complete batch=1 ...
```

`FileStore::Close` returned `void`. When `std::filesystem::rename` of the `.deskhub-part` file failed it logged, deleted the partial file, and returned. `FileReceiver` went on to ack `Accepted`, audit `stored` and `complete`, and the sender settled as `Done`. The file was gone and nobody knew.

`Close` now reports whether the file reached its final name, and a failure is treated like any other write failure: ack `WriteFailed`, stop the batch. `SPECIFICATION.md` H-16 already promised the host *"says so rather than failing silently"* — this was the path that did not keep that promise, so no doc change was needed.

## `refactor(quic):` drain each connection through a lookup that survives its callbacks

`Service()` iterated `connections_` with a range-for while `onConnected`, `onStream` and `onDatagram` ran inside the loop, and `DrainDatagrams` kept using its `Connection&` after every callback — while `DrainStreams` already guarded its own state with `listStillIntact`.

I checked: nothing reachable from those callbacks erases or inserts today (`CloseConnection` does not erase), **so no known bug depends on this.** It is hardening, not a fix — hence `refactor:`, so it does not land in the changelog's Fixed section.

## `ci:` run the Windows integration suite under AddressSanitizer

ASan/UBSan and TSan run on Linux and macOS. The crash happens on `windows-latest` and nowhere else, and a crash dump only names the frame the write landed in, not the write. This job builds the existing `asan-msvc` preset and runs the suite three times; an ASan report exits 42 so it is distinguishable from a crash ASan did not instrument.

This is the change most likely to actually catch the bug, because it runs where the bug is.

## What the crash dump showed

For whoever picks this up. From the run 33390283157 artifact, symbolized:

- Stack cookie of `SessionTransport::Deliver` (`SessionTransport.cpp:216`) smashed; stack is `HostLink::Loop → PumpReady → RecvFrom → QuicEndpoint::Poll → Service → DrainDatagrams → Deliver`.
- **Exactly 8 bytes** clobbered, at the cookie slot, with `0x29`. The saved registers above it and the return address are intact — so this is a targeted write, not a runaway `memcpy`.
- `queued` (the `TransportMessage` local, 32 bytes) ends exactly at the cookie slot.
- No ABI mismatch: `sizeof(TransportMessage)`=0x20, `vector`=0x18, self-consistent.
- Not a send/recv race: the other thread on that transport was blocked on `sendMutex_`.
- The `ReportStreamListOverwritten` instrumentation did **not** fire in that run.

I could not reproduce the crash in ~20 local runs, and 4 ASan runs produced no report — so the "quiche retains a stack pointer past the call" theory is **not** confirmed and should not be treated as the answer.

## Checks

Run and passing on Windows `x64-release`:

- `make format` — no changes
- `make lint` — OK
- `ctest` all three suites — 100% passed (core 0.25s, platform 649.69s, integration 330.30s)

**`make lint-tidy` was not run.** It does not work on my machine: `VsDevCmd.bat` fails here, and invoking `scripts/clang-tidy.sh` directly makes clang-tidy reject every entry in the MSVC `compile_commands.json` with `no such file or directory`. That gate is left to CI on this PR — please check it there.